### PR TITLE
feat: propagate response formats through agent loops

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -17,6 +17,8 @@ type RunInput struct {
 	Prompt gaictx.PromptInput
 	// MaxTokens overrides Definition.Limits.MaxTokens when it is positive.
 	MaxTokens int
+	// ResponseFormat requests the output shape for every model call in this run.
+	ResponseFormat ai.ResponseFormat
 	// Meta carries application data such as user, session, or request IDs.
 	Meta map[string]any
 }
@@ -168,6 +170,7 @@ func (a *Agent) newLoop(ctx context.Context, input RunInput) (*loop.Loop, error)
 	} else {
 		l.MaxTokens = a.def.Limits.MaxTokens
 	}
+	l.ResponseFormat = cloneResponseFormat(input.ResponseFormat)
 	return l, nil
 }
 

--- a/agent/e2e_test.go
+++ b/agent/e2e_test.go
@@ -103,10 +103,18 @@ func TestAgentWorkflowEndToEndWithToolCall(t *testing.T) {
 		},
 	})
 
-	workflow, err := assistant.NewRun(context.Background(), textRunInput("use echo"))
+	input := textRunInput("use echo")
+	input.ResponseFormat = ai.ResponseFormat{
+		Type:   ai.ResponseFormatJSONSchema,
+		Name:   "answer",
+		Schema: []byte(`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}`),
+	}
+	expectedSchema := string(input.ResponseFormat.Schema)
+	workflow, err := assistant.NewRun(context.Background(), input)
 	if err != nil {
 		t.Fatalf("NewRun failed: %v", err)
 	}
+	input.ResponseFormat.Schema[0] = '['
 	consumed := consumeWorkflow(t, workflow)
 	if len(consumed.errs) != 0 {
 		t.Fatalf("unexpected workflow errors: %v", consumed.errs)
@@ -160,6 +168,14 @@ func TestAgentWorkflowEndToEndWithToolCall(t *testing.T) {
 	}
 	if requests[0].MaxTokens != 64 || len(requests[0].Tools) != 1 || requests[0].Tools[0].Name != "echo" {
 		t.Fatalf("first request did not include limits and tools: %+v", requests[0])
+	}
+	for index, request := range requests {
+		if request.ResponseFormat.Type != ai.ResponseFormatJSONSchema || request.ResponseFormat.Name != "answer" || string(request.ResponseFormat.Schema) != expectedSchema {
+			t.Fatalf("request %d did not preserve response format: %+v", index, request.ResponseFormat)
+		}
+		if len(request.Tools) != 1 || request.Tools[0].Name != "echo" {
+			t.Fatalf("request %d did not preserve native tools: %+v", index, request.Tools)
+		}
 	}
 	if !strings.Contains(requests[1].Prompt, "tool res: tool says hi") {
 		t.Fatalf("second prompt did not include tool result:\n%s", requests[1].Prompt)

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -468,12 +468,19 @@ func tokenReasoning(tokens []ai.Token) string {
 func cloneRunInput(input RunInput) RunInput {
 	cloned := input
 	cloned.Prompt = input.Prompt.Clone()
+	cloned.ResponseFormat = cloneResponseFormat(input.ResponseFormat)
 	if input.Meta != nil {
 		cloned.Meta = make(map[string]any, len(input.Meta))
 		for key, value := range input.Meta {
 			cloned.Meta[key] = value
 		}
 	}
+	return cloned
+}
+
+func cloneResponseFormat(format ai.ResponseFormat) ai.ResponseFormat {
+	cloned := format
+	cloned.Schema = append([]byte(nil), format.Schema...)
 	return cloned
 }
 

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -39,6 +39,8 @@ type Loop struct {
 	MaxLoopIterations int
 	// MaxTokens limits model output for each generation request.
 	MaxTokens int
+	// ResponseFormat requests the output shape for each model generation.
+	ResponseFormat ai.ResponseFormat
 	// RetryCount is the number of model stream failures retried before stopping.
 	RetryCount int
 	// PromptBuilder constructs the prompt for each iteration.
@@ -60,6 +62,9 @@ func (l *Loop) Validate() error {
 	}
 	if l.PromptBuilder == nil {
 		return ErrPromptNotConfigured
+	}
+	if err := l.ResponseFormat.Validate(); err != nil {
+		return err
 	}
 	return nil
 }
@@ -183,9 +188,10 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 				}
 
 				request := ai.AIRequest{
-					Prompt:    prompt,
-					MaxTokens: l.MaxTokens,
-					Tools:     toolDefinitions,
+					Prompt:         prompt,
+					MaxTokens:      l.MaxTokens,
+					Tools:          toolDefinitions,
+					ResponseFormat: l.ResponseFormat,
 				}
 
 				tokens := l.Model.GenerateStream(iterCtx, request)

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -250,6 +250,22 @@ func loopEventsOfType(events []loop.Event, eventType loop.EventType) []loop.Even
 	return filtered
 }
 
+func TestLoopRejectsInvalidResponseFormatWithoutWrapping(t *testing.T) {
+	t.Parallel()
+
+	model := &scriptedStreamModel{}
+	l := loop.New(model, nil, testPromptBuilder(), nil)
+	l.ResponseFormat = ai.ResponseFormat{Type: ai.ResponseFormatJSONSchema}
+
+	err := loopError(collectLoopEvents(t, l, context.Background()))
+	if !errors.Is(err, ai.ErrInvalidResponseFormat) {
+		t.Fatalf("expected invalid response format error, got %v", err)
+	}
+	if len(model.Requests()) != 0 {
+		t.Fatalf("model must not be called for an invalid response format")
+	}
+}
+
 func renderTestMessages(messages []gaictx.Message) string {
 	var builder strings.Builder
 	for i, message := range messages {


### PR DESCRIPTION
Closes #50

## Summary
- add a per-run response format to `agent.RunInput` and propagate it through every loop request
- preserve native tool definitions while structured output is requested
- deep-copy JSON schemas and fail invalid formats before model generation

## Validation
- `go test ./...`
- `go vet ./...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the desired response format for agent runs and model requests.
  * JSON Schema response formats are now preserved throughout a run and applied consistently to every model request.

* **Bug Fixes**
  * Prevented response schemas from being altered unexpectedly after a run starts.
  * Invalid response format configurations are rejected before contacting the model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->