### PR TITLE
feat(agent): expose reasoning configuration

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -54,6 +54,8 @@ type Definition struct {
 	Prompt Prompt
 	// Limits configures loop execution defaults.
 	Limits Limits
+	// Reasoning configures model reasoning/thinking behavior for every model call.
+	Reasoning ai.ReasoningConfig
 	// Tokenizer overrides Model.Tokenizer when it is non-nil.
 	Tokenizer ai.Tokenizer
 	// ToolResponseProcessor can transform tool responses before they enter the transcript.
@@ -171,6 +173,7 @@ func (a *Agent) newLoop(ctx context.Context, input RunInput) (*loop.Loop, error)
 		l.MaxTokens = a.def.Limits.MaxTokens
 	}
 	l.ResponseFormat = cloneResponseFormat(input.ResponseFormat)
+	l.Reasoning = a.def.Reasoning
 	return l, nil
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -93,6 +93,12 @@ func TestAgentNewRunCreatesLoop(t *testing.T) {
 			RetryCount:        1,
 			MaxTokens:         9,
 		},
+		Reasoning: ai.ReasoningConfig{
+			Enabled:         true,
+			IncludeThoughts: true,
+			BudgetTokens:    128,
+			Effort:          ai.ReasoningEffortHigh,
+		},
 	})
 
 	run, err := assistant.NewRun(context.Background(), textRunInput("input"))
@@ -113,6 +119,9 @@ func TestAgentNewRunCreatesLoop(t *testing.T) {
 	}
 	if run.Loop.MaxTokens != 9 {
 		t.Fatalf("expected max tokens 9, got %d", run.Loop.MaxTokens)
+	}
+	if run.Loop.Reasoning != (ai.ReasoningConfig{Enabled: true, IncludeThoughts: true, BudgetTokens: 128, Effort: ai.ReasoningEffortHigh}) {
+		t.Fatalf("expected configured reasoning, got %+v", run.Loop.Reasoning)
 	}
 	if builder == nil || builder.tokenizer == nil {
 		t.Fatal("expected model tokenizer to be set on prompt builder")

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -41,6 +41,8 @@ type Loop struct {
 	MaxTokens int
 	// ResponseFormat requests the output shape for each model generation.
 	ResponseFormat ai.ResponseFormat
+	// Reasoning configures model reasoning/thinking behavior for each model generation.
+	Reasoning ai.ReasoningConfig
 	// RetryCount is the number of model stream failures retried before stopping.
 	RetryCount int
 	// PromptBuilder constructs the prompt for each iteration.
@@ -192,6 +194,7 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 					MaxTokens:      l.MaxTokens,
 					Tools:          toolDefinitions,
 					ResponseFormat: l.ResponseFormat,
+					Reasoning:      l.Reasoning,
 				}
 
 				tokens := l.Model.GenerateStream(iterCtx, request)

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -240,6 +240,35 @@ func loopError(events []loop.Event) error {
 	return err
 }
 
+func TestLoopPropagatesReasoningToModelRequests(t *testing.T) {
+	t.Parallel()
+
+	for _, reasoning := range []ai.ReasoningConfig{
+		{},
+		{Enabled: true, IncludeThoughts: true, BudgetTokens: 128, Effort: ai.ReasoningEffortHigh},
+	} {
+		reasoning := reasoning
+		t.Run(fmt.Sprintf("enabled=%t", reasoning.Enabled), func(t *testing.T) {
+			t.Parallel()
+
+			model := &scriptedStreamModel{sequences: [][]ai.Token{{{Type: ai.TokenTypeText, Text: "done"}}}}
+			l := loop.New(model, nil, &countingPromptBuilder{}, nil)
+			l.Reasoning = reasoning
+
+			if err := loopError(collectLoopEvents(t, l, context.Background())); err != nil {
+				t.Fatalf("unexpected loop error: %v", err)
+			}
+			requests := model.Requests()
+			if len(requests) != 1 {
+				t.Fatalf("expected 1 model request, got %d", len(requests))
+			}
+			if requests[0].Reasoning != reasoning {
+				t.Fatalf("expected reasoning %+v, got %+v", reasoning, requests[0].Reasoning)
+			}
+		})
+	}
+}
+
 func loopEventsOfType(events []loop.Event, eventType loop.EventType) []loop.Event {
 	var filtered []loop.Event
 	for _, event := range events {


### PR DESCRIPTION
## Summary
- expose `ai.ReasoningConfig` on `agent.Definition`
- propagate it through the loop to every model request
- cover configured and zero-value propagation

Closes #46

## Validation
- `go test ./agent ./loop ./ai/gemini`
- `go test -race ./agent ./loop`
- `go test ./...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable model reasoning controls for agent runs.
  * Reasoning settings, including thought visibility and effort or budget options, are now applied consistently to model requests.

* **Tests**
  * Added coverage confirming reasoning configurations are correctly propagated during agent and workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->