### PR TITLE
fix(openai): address remaining review feedback

### DIFF
--- a/ai/openai/model.go
+++ b/ai/openai/model.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/lace-ai/gai"
 	"github.com/lace-ai/gai/ai"
 	sdk "github.com/openai/openai-go"
 	"github.com/openai/openai-go/option"
@@ -33,7 +34,7 @@ func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (*ai.AIResponse,
 	if err != nil {
 		return nil, err
 	}
-	response, err := m.client().Chat.Completions.New(ctx, params)
+	response, err := m.client(false).Chat.Completions.New(ctx, params)
 	if err != nil {
 		return nil, err
 	}
@@ -72,8 +73,16 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
 			return
 		}
-		stream := m.client().Chat.Completions.NewStreaming(ctx, params)
-		defer stream.Close()
+		stream := m.client(true).Chat.Completions.NewStreaming(ctx, params)
+		defer func() {
+			if err := stream.Close(); err != nil && m.provider.debug != nil {
+				m.provider.debug.Emit(ctx, gai.DebugEvent{
+					Name:   "stream_close_failed",
+					Source: "ai:openai.Model.GenerateStream",
+					Err:    err,
+				})
+			}
+		}()
 		calls := map[int64]*streamToolCall{}
 		for stream.Next() {
 			chunk := stream.Current()
@@ -190,6 +199,7 @@ func applyTools(params *sdk.ChatCompletionNewParams, definitions []ai.ToolDefini
 		return nil
 	}
 	params.Tools = make([]sdk.ChatCompletionToolParam, 0, len(definitions))
+	available := make(map[string]struct{}, len(definitions))
 	for _, definition := range definitions {
 		if err := definition.Validate(); err != nil {
 			return err
@@ -199,6 +209,25 @@ func applyTools(params *sdk.ChatCompletionNewParams, definitions []ai.ToolDefini
 			return fmt.Errorf("decode tool %q schema: %w", definition.Name, err)
 		}
 		params.Tools = append(params.Tools, sdk.ChatCompletionToolParam{Function: shared.FunctionDefinitionParam{Name: definition.Name, Description: param.NewOpt(definition.Description), Parameters: schema}})
+		available[definition.Name] = struct{}{}
+	}
+	if choice.Mode == ai.ToolChoiceRequired && len(choice.Names) > 0 {
+		allowed := make(map[string]struct{}, len(choice.Names))
+		for _, name := range choice.Names {
+			if _, ok := available[name]; !ok {
+				return fmt.Errorf("required tool %q is not defined", name)
+			}
+			allowed[name] = struct{}{}
+		}
+		if len(choice.Names) > 1 {
+			filtered := make([]sdk.ChatCompletionToolParam, 0, len(allowed))
+			for _, tool := range params.Tools {
+				if _, ok := allowed[tool.Function.Name]; ok {
+					filtered = append(filtered, tool)
+				}
+			}
+			params.Tools = filtered
+		}
 	}
 	switch choice.Mode {
 	case "", ai.ToolChoiceAuto, ai.ToolChoiceNone, ai.ToolChoiceRequired:
@@ -235,8 +264,12 @@ func applyResponseFormat(params *sdk.ChatCompletionNewParams, format ai.Response
 	}
 }
 
-func (m *Model) client() *sdk.Client {
-	client := sdk.NewClient(option.WithAPIKey(m.provider.apiKey), option.WithBaseURL(m.provider.baseURL), option.WithHTTPClient(m.provider.httpClient), option.WithMaxRetries(0))
+func (m *Model) client(streaming bool) *sdk.Client {
+	httpClient := m.provider.httpClient
+	if streaming {
+		httpClient = m.provider.streamingHTTPClient()
+	}
+	client := sdk.NewClient(option.WithAPIKey(m.provider.apiKey), option.WithBaseURL(m.provider.baseURL), option.WithHTTPClient(httpClient), option.WithMaxRetries(0))
 	return &client
 }
 

--- a/ai/openai/model_test.go
+++ b/ai/openai/model_test.go
@@ -130,6 +130,31 @@ func TestBuildChatCompletionParamsRejectsReasoningEffortForNonReasoningModels(t 
 	}
 }
 
+func TestApplyToolsRestrictsRequiredToolNames(t *testing.T) {
+	definitions := []ai.ToolDefinition{
+		{Type: "function", Name: "first", Description: "First", Parameters: json.RawMessage(`{"type":"object"}`)},
+		{Type: "function", Name: "second", Description: "Second", Parameters: json.RawMessage(`{"type":"object"}`)},
+		{Type: "function", Name: "excluded", Description: "Excluded", Parameters: json.RawMessage(`{"type":"object"}`)},
+	}
+	params, err := buildChatCompletionParams(GPT41Mini, ai.AIRequest{
+		Prompt: "hello", Tools: definitions,
+		ToolChoice: ai.ToolChoice{Mode: ai.ToolChoiceRequired, Names: []string{"second", "first"}},
+	}, false)
+	if err != nil {
+		t.Fatalf("buildChatCompletionParams returned error: %v", err)
+	}
+	if len(params.Tools) != 2 || params.Tools[0].Function.Name != "first" || params.Tools[1].Function.Name != "second" {
+		t.Fatalf("unexpected restricted tools: %#v", params.Tools)
+	}
+
+	if _, err := buildChatCompletionParams(GPT41Mini, ai.AIRequest{
+		Prompt: "hello", Tools: definitions,
+		ToolChoice: ai.ToolChoice{Mode: ai.ToolChoiceRequired, Names: []string{"missing"}},
+	}, false); err == nil {
+		t.Fatal("expected an undefined required tool to be rejected")
+	}
+}
+
 func TestModelGenerateValidatesToolCallArguments(t *testing.T) {
 	for _, tt := range []struct {
 		name      string

--- a/ai/openai/provider.go
+++ b/ai/openai/provider.go
@@ -40,6 +40,14 @@ func (p *Provider) Validate() error {
 
 func (p *Provider) Name() string { return "openai" }
 
+// streamingHTTPClient returns a client whose request lifetime is controlled by
+// the caller's context, rather than the provider's non-streaming timeout.
+func (p *Provider) streamingHTTPClient() *http.Client {
+	client := *p.httpClient
+	client.Timeout = 0
+	return &client
+}
+
 func (p *Provider) Model(name string) (ai.Model, error) {
 	if err := p.Validate(); err != nil {
 		return nil, err

--- a/ai/openai/provider_test.go
+++ b/ai/openai/provider_test.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/lace-ai/gai/ai"
 )
@@ -44,5 +45,21 @@ func TestProviderValidation(t *testing.T) {
 	}
 	if model, err := New("test-key", nil).Model("unknown"); !errors.Is(err, ai.ErrModelNotFound) || model != nil {
 		t.Fatalf("expected unknown model rejection, got model=%#v err=%v", model, err)
+	}
+}
+
+func TestStreamingHTTPClientDoesNotApplyProviderTimeout(t *testing.T) {
+	p := New("test-key", nil)
+	p.httpClient.Timeout = time.Millisecond
+
+	streaming := p.streamingHTTPClient()
+	if streaming == p.httpClient {
+		t.Fatal("streamingHTTPClient must return a copy")
+	}
+	if streaming.Timeout != 0 {
+		t.Fatalf("expected no streaming client timeout, got %s", streaming.Timeout)
+	}
+	if p.httpClient.Timeout != time.Millisecond {
+		t.Fatalf("streamingHTTPClient mutated provider timeout: %s", p.httpClient.Timeout)
 	}
 }


### PR DESCRIPTION
Follow-up to #56 addressing still-valid review findings.

- preserve required multi-tool allowlists by filtering exposed tools
- remove the fixed client timeout for streaming requests while retaining it for non-streaming requests
- report streaming cleanup failures through the debug sink

Validation: `go test ./...`