### PR TITLE
fix(mistral): preserve streamed tool call IDs

### DIFF
--- a/ai/mistral/model.go
+++ b/ai/mistral/model.go
@@ -445,8 +445,12 @@ func (a *mistralToolCallAccumulator) ready(final bool) []ai.ToolCall {
 		if callType == "" {
 			callType = "function"
 		}
+		toolCallID := strings.TrimSpace(state.id.String())
+		if toolCallID == "" {
+			toolCallID = ai.GenerateToolCallID(toolName)
+		}
 		result = append(result, ai.ToolCall{
-			ID:   ai.GenerateToolCallID(toolName),
+			ID:   toolCallID,
 			Type: callType,
 			Name: toolName,
 			Args: args,

--- a/ai/mistral/model_test.go
+++ b/ai/mistral/model_test.go
@@ -507,8 +507,8 @@ func TestModelGenerateStreamToolCall(t *testing.T) {
 	if tok.ToolCall == nil {
 		t.Fatal("expected ToolCall to be populated, got nil")
 	}
-	if !strings.HasPrefix(tok.ToolCall.ID, "call_my_tool_") {
-		t.Fatalf("expected generated ToolCall.ID for my_tool, got %q", tok.ToolCall.ID)
+	if tok.ToolCall.ID != "call_abc" {
+		t.Fatalf("expected provider ToolCall.ID=call_abc, got %q", tok.ToolCall.ID)
 	}
 	if tok.ToolCall.Type != "function" {
 		t.Fatalf("expected ToolCall.Type=function, got %q", tok.ToolCall.Type)
@@ -572,6 +572,9 @@ func TestModelGenerateStreamToolCallDeltas(t *testing.T) {
 	}
 	if tok.ToolCall == nil {
 		t.Fatal("expected ToolCall to be populated, got nil")
+	}
+	if tok.ToolCall.ID != "call_abc" {
+		t.Fatalf("expected accumulated provider ToolCall.ID=call_abc, got %q", tok.ToolCall.ID)
 	}
 	if tok.ToolCall.Name != "my_tool" {
 		t.Fatalf("expected ToolCall.Name=my_tool, got %q", tok.ToolCall.Name)


### PR DESCRIPTION
## Summary
- preserve Mistral provider-issued IDs for streamed tool calls
- retain generated IDs only when Mistral omits one
- cover complete and fragmented provider ID stream deltas

## Validation
- `go test ./...`
- `git diff --check`

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved tool call IDs provided by the Mistral streaming response.
  * Generated a fallback ID only when the response does not include one.
  * Improved consistency of tool call tracking during streamed interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->