### PR TITLE
fix(ci): restrict workflow token permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,10 @@
 
 name: Go
 
+# This workflow only checks out and builds/tests the repository.
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary
- declare least-privilege `contents: read` token permissions for the Go workflow
- document why the workflow needs no broader permissions

## Validation
- `go test ./...`
- workflow YAML parses successfully
- `git diff --check`

Closes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted the automated build and test workflow to read-only repository access.
  * Added documentation clarifying the workflow’s checkout, build, and test scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->