### PR TITLE
feat(agent): add ordered workflow event stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,11 +529,35 @@ The `agent/summary` package is a built-in component. `summary.Definition` return
 
 </summary>
 
-`Agent.NewRun` creates a single-use `Workflow`. Calling `Workflow.Run` starts the
-primary loop and passes its stream through every entry in `Definition.Middleware`
-in declaration order. Callers must consume the token, status, and error channels.
-After they close, `Workflow.Result()` contains the immutable primary result, the
-final visible output, accumulated errors, and named middleware stages.
+`Agent.NewRun` creates a single-use `Workflow`. For consumers that need one
+causally ordered primary-agent stream, call `Workflow.RunEvents`:
+
+```go
+for event := range workflow.RunEvents(ctx) {
+  switch event.Type {
+  case loop.EventToken:
+    fmt.Print(event.Token.Text)
+  case loop.EventRetry:
+    // Remove output associated with event.AttemptID from the visible transcript.
+  case loop.EventIterationDone, loop.EventDone:
+    // Read completion metadata in event.
+  case loop.EventError, loop.EventCanceled:
+    // Handle terminal failure or cancellation.
+  }
+}
+```
+
+`RunEvents` forwards the loop's ordered events unchanged, including attempt
+starts, tokens, retry rollbacks, completed iterations, errors, cancellation, and
+done. It is the preferred API for new primary-agent streaming consumers.
+
+`Workflow.Run` remains the compatibility API for middleware workflows. It starts
+the primary loop and passes its stream through every entry in
+`Definition.Middleware` in declaration order. Callers must consume the token,
+status, and error channels. After they close, `Workflow.Result()` contains the
+immutable primary result, the final visible output, accumulated errors, and named
+middleware stages. The legacy middleware interface has separate channels, so it
+cannot preserve a total event order; use `Run` when middleware output is needed.
 
 An ordinary agent can become middleware with `NewAgentMiddleware`. By default it
 receives the current visible text as named `upstream_output` context, plus the

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ go get github.com/lace-ai/gai
 ### 🧭 Usage
 
 The shortest path is to create a provider model, define an agent, create a
-single-use workflow, and consume all three workflow streams. Import GAI's
+single-use workflow, and consume its ordered event stream. Import GAI's
 `context` package with an alias so it does not conflict with the standard
-library package.
+library package, and import `loop` for the event types.
 
 ```go
 provider := gemini.New(os.Getenv("GEMINI_API_KEY"), nil)
@@ -84,32 +84,15 @@ if err != nil {
   return err
 }
 
-tokens, statuses, errs := workflow.Run(ctx)
-statusDone := make(chan struct{})
-go func() {
-  defer close(statusDone)
-  for range statuses {
-  }
-}()
-
-var runErr error
-errorDone := make(chan struct{})
-go func() {
-  defer close(errorDone)
-  for err := range errs {
-    if err != nil && runErr == nil {
-      runErr = err
+for event := range workflow.RunEvents(ctx) {
+  switch event.Type {
+  case loop.EventToken:
+    if event.Token != nil {
+      fmt.Print(event.Token.Text)
     }
+  case loop.EventError:
+    return event.Err
   }
-}()
-
-for token := range tokens {
-  fmt.Print(token.Text)
-}
-<-statusDone
-<-errorDone
-if runErr != nil {
-  return runErr
 }
 
 result := workflow.Result()

--- a/agent/e2e_test.go
+++ b/agent/e2e_test.go
@@ -410,6 +410,10 @@ func TestAgentWorkflowRunEventsPreservesRetryOrdering(t *testing.T) {
 	if events[4].Token == nil || events[4].Token.Text != "final" || events[4].AttemptID != 2 {
 		t.Fatalf("unexpected final token event: %#v", events[4])
 	}
+	result := workflow.Result()
+	if !result.Complete || result.Text != "partialfinal" || result.Primary.Text != "partialfinal" {
+		t.Fatalf("RunEvents did not finalize workflow result: %+v", result)
+	}
 }
 
 func eventTypes(events []loop.Event) []loop.EventType {

--- a/agent/e2e_test.go
+++ b/agent/e2e_test.go
@@ -3,6 +3,7 @@ package agent_test
 import (
 	"context"
 	"errors"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -357,4 +358,64 @@ func TestAgentWorkflowEndToEndWithAppendMiddleware(t *testing.T) {
 	if len(result.Stages) != 1 || result.Stages[0].Name != "audit" || result.Stages[0].Result.Text != " audited" {
 		t.Fatalf("unexpected middleware stages: %+v", result.Stages)
 	}
+}
+
+func TestAgentWorkflowRunEventsPreservesRetryOrdering(t *testing.T) {
+	model := &scriptedWorkflowModel{
+		scripts: [][]ai.Token{
+			{
+				{Type: ai.TokenTypeText, Text: "partial"},
+				{Err: errors.New("retriable stream error")},
+			},
+			{{Type: ai.TokenTypeText, Text: "final"}},
+		},
+	}
+	assistant := agent.New(agent.Definition{
+		Name:  "retry-events",
+		Model: model,
+		Prompt: func(context.Context, agent.RunInput) (gaictx.PromptBuilder, error) {
+			return gaictx.New(gaictx.Definition{Renderer: &gaictx.SimpleRenderer{}}), nil
+		},
+		Limits: agent.Limits{MaxLoopIterations: 1},
+	})
+
+	workflow, err := assistant.NewRun(context.Background(), textRunInput("retry"))
+	if err != nil {
+		t.Fatalf("NewRun failed: %v", err)
+	}
+	workflow.Loop.RetryCount = 1
+
+	var events []loop.Event
+	for event := range workflow.RunEvents(context.Background()) {
+		events = append(events, event)
+	}
+
+	if got, want := eventTypes(events), []loop.EventType{
+		loop.EventAttemptStart,
+		loop.EventToken,
+		loop.EventRetry,
+		loop.EventAttemptStart,
+		loop.EventToken,
+		loop.EventIterationDone,
+		loop.EventDone,
+	}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected event order: got %v want %v", got, want)
+	}
+	if events[1].Token == nil || events[1].Token.Text != "partial" || events[1].AttemptID != 1 {
+		t.Fatalf("unexpected first token event: %#v", events[1])
+	}
+	if events[2].AttemptID != 1 || events[2].RetryCount != 1 || events[2].Iteration == nil {
+		t.Fatalf("retry event did not preserve attempt metadata: %#v", events[2])
+	}
+	if events[4].Token == nil || events[4].Token.Text != "final" || events[4].AttemptID != 2 {
+		t.Fatalf("unexpected final token event: %#v", events[4])
+	}
+}
+
+func eventTypes(events []loop.Event) []loop.EventType {
+	types := make([]loop.EventType, len(events))
+	for i, event := range events {
+		types[i] = event.Type
+	}
+	return types
 }

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -160,25 +160,31 @@ func middlewareIsNil(item Middleware) bool {
 	}
 }
 
-// Run starts the workflow and returns the final transformed stream. Callers must
-// consume all three channels. It can be called only once.
+// RunEvents starts the workflow and returns its ordered primary-agent event stream.
+// The stream is the preferred API for consumers that need causal ordering between
+// tokens, retries, completed iterations, errors, and cancellation. It can be
+// called only once. Middleware remains available through Run because the legacy
+// three-channel Middleware interface cannot preserve a total event order.
+func (w *Workflow) RunEvents(ctx context.Context) <-chan loop.Event {
+	if err := w.begin(); err != nil {
+		return failedEventStream(err)
+	}
+	return w.Loop.Run(ctx)
+}
+
+// Run starts the workflow and returns the final transformed stream. Deprecated:
+// prefer RunEvents for new consumers. Callers must consume all three channels.
+// It can be called only once.
 func (w *Workflow) Run(ctx context.Context) (<-chan ai.Token, <-chan loop.IterationInformation, <-chan error) {
-	if w == nil || w.Loop == nil {
-		return failedStream(ErrWorkflowNotConfigured)
+	if err := w.begin(); err != nil {
+		return failedStream(err)
 	}
-
-	w.mu.Lock()
-	if w.started {
-		w.mu.Unlock()
-		return failedStream(ErrWorkflowAlreadyRun)
-	}
-	w.started = true
-	w.mu.Unlock()
-
 	ctx, runObs := newAgentRunObserver(ctx, w)
 	ctx, obs := newWorkflowObserver(ctx, w)
+	events := w.Loop.Run(ctx)
+
 	obs.Started(ctx)
-	stream := w.capturePrimary(ctx, loopEventsToStream(ctx, w.Loop.Run(ctx)), obs)
+	stream := w.capturePrimary(ctx, loopEventsToStream(ctx, events), obs)
 	run := &MiddlewareContext{workflow: w}
 	for _, middleware := range w.middleware {
 		stream = middleware.Process(ctx, run, stream)
@@ -410,6 +416,27 @@ func captureStream(ctx context.Context, upstream Stream, completed func(captured
 	}()
 
 	return Stream{Tokens: tokens, Statuses: statuses, Errors: errs}
+}
+
+func (w *Workflow) begin() error {
+	if w == nil || w.Loop == nil {
+		return ErrWorkflowNotConfigured
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.started {
+		return ErrWorkflowAlreadyRun
+	}
+	w.started = true
+	return nil
+}
+
+func failedEventStream(err error) <-chan loop.Event {
+	events := make(chan loop.Event, 1)
+	events <- loop.ErrorEvent(err)
+	close(events)
+	return events
 }
 
 func failedStream(err error) (<-chan ai.Token, <-chan loop.IterationInformation, <-chan error) {

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -169,7 +169,10 @@ func (w *Workflow) RunEvents(ctx context.Context) <-chan loop.Event {
 	if err := w.begin(); err != nil {
 		return failedEventStream(err)
 	}
-	return w.Loop.Run(ctx)
+	ctx, runObs := newAgentRunObserver(ctx, w)
+	ctx, obs := newWorkflowObserver(ctx, w)
+	obs.Started(ctx)
+	return w.captureEvents(ctx, w.Loop.Run(ctx), obs, runObs)
 }
 
 // Run starts the workflow and returns the final transformed stream. Deprecated:
@@ -324,6 +327,61 @@ func (w *Workflow) captureFinal(ctx context.Context, upstream Stream, obs *workf
 		obs.Finished(ctx, result)
 		runObs.Finished(result)
 	})
+}
+
+func (w *Workflow) captureEvents(ctx context.Context, upstream <-chan loop.Event, obs *workflowObserver, runObs *agentRunObserver) <-chan loop.Event {
+	events := make(chan loop.Event, 32)
+	go func() {
+		defer close(events)
+
+		var tokens []ai.Token
+		var errs []error
+		var canceled bool
+		var cancellationErr error
+		for event := range upstream {
+			switch event.Type {
+			case loop.EventToken:
+				if event.Token != nil {
+					tokens = append(tokens, *event.Token)
+				}
+			case loop.EventError:
+				if event.Err != nil {
+					errs = append(errs, event.Err)
+				}
+			case loop.EventCanceled:
+				canceled = true
+				cancellationErr = event.Err
+			}
+			events <- event
+		}
+
+		primary := AgentResult{
+			Tokens:          cloneTokens(tokens),
+			Text:            tokenText(tokens),
+			Reasoning:       tokenReasoning(tokens),
+			Messages:        cloneMessages(w.Loop.Messages()),
+			Iterations:      cloneIterations(w.Loop.Iterations),
+			Errors:          append([]error(nil), errs...),
+			Canceled:        canceled,
+			CancellationErr: cancellationErr,
+		}
+		w.mu.Lock()
+		w.result.Primary = primary
+		w.result.Tokens = cloneTokens(tokens)
+		w.result.Text = primary.Text
+		w.result.Reasoning = primary.Reasoning
+		w.result.Errors = append([]error(nil), errs...)
+		w.result.Canceled = canceled
+		w.result.CancellationErr = cancellationErr
+		w.result.Complete = true
+		result := cloneWorkflowResult(w.result)
+		w.mu.Unlock()
+
+		obs.PrimaryFinished(ctx, primary)
+		obs.Finished(ctx, result)
+		runObs.Finished(result)
+	}()
+	return events
 }
 
 func (w *Workflow) addStage(stage StageResult, tokens []ai.Token) {


### PR DESCRIPTION
## Summary
- add `Workflow.RunEvents` as the ordered primary-agent streaming API
- retain `Workflow.Run` as the compatibility adapter for legacy middleware
- document migration and cover retry event ordering without changing retry logic

## Validation
- `go test ./...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Workflow.RunEvents` for streaming workflow events in causal order.
  * Event streams now expose attempts, tokens, retries, completed iterations, errors, cancellation, and completion.
  * Retry-related events preserve their correct ordering and include relevant metadata.
* **Documentation**
  * Clarified when to use `RunEvents` versus the existing `Run` API.
  * Documented event handling, channel consumption requirements, and ordering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->