### PR TITLE
fix(agent): avoid prompt tool protocol for native models

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,9 +735,9 @@ Tool calls are expected to arrive as JSON with this shape:
 ```
 
 Tool call IDs are generated internally by the runtime and are not model-controlled.
-When a provider supports native tool calling, the loop sends tool definitions
-through `AIRequest.Tools`. Prompt-rendered JSON tool calls are retained as a
-fallback compatibility protocol.
+Models that implement `ai.NativeToolModel` receive tool definitions through
+`AIRequest.Tools` without the prompt-rendered JSON tool protocol. Models that
+do not implement it retain that text protocol as a compatibility fallback.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -735,9 +735,11 @@ Tool calls are expected to arrive as JSON with this shape:
 ```
 
 Tool call IDs are generated internally by the runtime and are not model-controlled.
-Models that implement `ai.NativeToolModel` receive tool definitions through
-`AIRequest.Tools` without the prompt-rendered JSON tool protocol. Models that
-do not implement it retain that text protocol as a compatibility fallback.
+Models whose `ai.NativeToolModel.NativeTools()` method returns `true` receive
+tool definitions through `AIRequest.Tools` without the prompt-rendered JSON
+tool protocol. Models that do not report native support retain that text
+protocol as a compatibility fallback. A prompt builder with an existing
+`tool_definitions` source also explicitly preserves the text protocol.
 
 </details>
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -43,10 +43,11 @@ type Definition struct {
 	Name string
 	// Model performs the agent's model calls.
 	Model ai.Model
-	// Tools are available to the model during loop execution. For models that do
-	// not implement ai.NativeToolModel, their definitions and text-based
-	// invocation protocol are added as the first prompt context source unless
-	// its builder already contains a tool_definitions source.
+	// Tools are available to the model during loop execution. Unless the model
+	// implements ai.NativeToolModel and NativeTools returns true, their
+	// definitions and text-based invocation protocol are added as the first
+	// prompt context source unless its builder already contains a
+	// tool_definitions source.
 	Tools []loop.Tool
 	// ToolDefinitionOptions configure the auto-prepended tool-definitions prompt
 	// source used for Tools.

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -43,9 +43,10 @@ type Definition struct {
 	Name string
 	// Model performs the agent's model calls.
 	Model ai.Model
-	// Tools are available to the model during loop execution. Their definitions
-	// and text-based invocation protocol are added as the first prompt context
-	// source unless its builder already contains a tool_definitions source.
+	// Tools are available to the model during loop execution. For models that do
+	// not implement ai.NativeToolModel, their definitions and text-based
+	// invocation protocol are added as the first prompt context source unless
+	// its builder already contains a tool_definitions source.
 	Tools []loop.Tool
 	// ToolDefinitionOptions configure the auto-prepended tool-definitions prompt
 	// source used for Tools.
@@ -141,7 +142,7 @@ func (a *Agent) newLoop(ctx context.Context, input RunInput) (*loop.Loop, error)
 		return nil, loop.ErrPromptNotConfigured
 	}
 	promptBuilder.SetInput(input.Prompt)
-	if len(a.def.Tools) > 0 && !hasContextSource(promptBuilder, "tool_definitions") {
+	if len(a.def.Tools) > 0 && !usesNativeTools(a.def.Model) && !hasContextSource(promptBuilder, "tool_definitions") {
 		toolSource, err := tooldefinitions.New(nil, a.def.Tools, a.def.DebugSink, a.def.ToolDefinitionOptions...)
 		if err != nil {
 			return nil, err
@@ -175,6 +176,11 @@ func (a *Agent) newLoop(ctx context.Context, input RunInput) (*loop.Loop, error)
 	l.ResponseFormat = cloneResponseFormat(input.ResponseFormat)
 	l.Reasoning = a.def.Reasoning
 	return l, nil
+}
+
+func usesNativeTools(model ai.Model) bool {
+	native, ok := model.(ai.NativeToolModel)
+	return ok && native.NativeTools()
 }
 
 type contextSourceLookup interface {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -28,6 +28,12 @@ type nativeToolWorkflowModel struct {
 
 func (nativeToolWorkflowModel) NativeTools() bool { return true }
 
+type disabledNativeToolWorkflowModel struct {
+	*scriptedWorkflowModel
+}
+
+func (disabledNativeToolWorkflowModel) NativeTools() bool { return false }
+
 func (s testContextSource) Name() string { return s.name }
 func (s testContextSource) Function(context.Context, int) (gaictx.Part, error) {
 	return gaictx.NewTextPart(s.name), nil
@@ -214,6 +220,37 @@ func TestAgentNativeToolModelOmitsPromptToolProtocol(t *testing.T) {
 	}
 	if strings.Contains(requests[0].Prompt, `{"type":"function","name":"<tool-name>","arguments":{...}}`) {
 		t.Fatalf("native tool model request included prompt tool protocol:\n%s", requests[0].Prompt)
+	}
+}
+
+func TestAgentNativeToolModelWithoutSupportAddsPromptToolProtocol(t *testing.T) {
+	t.Parallel()
+
+	builder := gaictx.New(gaictx.Definition{Renderer: &gaictx.SimpleRenderer{}})
+	assistant := agent.New(agent.Definition{
+		Model: disabledNativeToolWorkflowModel{&scriptedWorkflowModel{}},
+		Tools: []loop.Tool{loop.NewEchoTool()},
+		Prompt: func(context.Context, agent.RunInput) (gaictx.PromptBuilder, error) {
+			return builder, nil
+		},
+	})
+
+	run, err := assistant.NewRun(context.Background(), textRunInput("use echo"))
+	if err != nil {
+		t.Fatalf("NewRun failed: %v", err)
+	}
+	if len(builder.ContextSources) != 1 || builder.ContextSources[0].Name() != "tool_definitions" {
+		t.Fatalf("disabled native tool model did not add prompt tool protocol: %+v", builder.ContextSources)
+	}
+	if _, err := run.Loop.PromptBuilder.BuildContext(context.Background()); err != nil {
+		t.Fatalf("BuildContext failed: %v", err)
+	}
+	prompt, err := run.Loop.PromptBuilder.BuildPrompt(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BuildPrompt failed: %v", err)
+	}
+	if !strings.Contains(prompt, `{"type":"function","name":"<tool-name>","arguments":{...}}`) {
+		t.Fatalf("disabled native tool model prompt missing tool protocol:\n%s", prompt)
 	}
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -22,6 +22,12 @@ type testPromptBuilder struct {
 
 type testContextSource struct{ name string }
 
+type nativeToolWorkflowModel struct {
+	*scriptedWorkflowModel
+}
+
+func (nativeToolWorkflowModel) NativeTools() bool { return true }
+
 func (s testContextSource) Name() string { return s.name }
 func (s testContextSource) Function(context.Context, int) (gaictx.Part, error) {
 	return gaictx.NewTextPart(s.name), nil
@@ -168,6 +174,46 @@ func TestAgentToolsAutomaticallyAddPromptContract(t *testing.T) {
 		if !strings.Contains(prompt, expected) {
 			t.Fatalf("automatic tool prompt missing %q:\n%s", expected, prompt)
 		}
+	}
+}
+
+func TestAgentNativeToolModelOmitsPromptToolProtocol(t *testing.T) {
+	t.Parallel()
+
+	builder := gaictx.New(gaictx.Definition{
+		Renderer:       &gaictx.SimpleRenderer{},
+		ContextSources: []gaictx.ContextSource{testContextSource{name: "application_context"}},
+	})
+	model := &scriptedWorkflowModel{scripts: [][]ai.Token{{}}}
+	assistant := agent.New(agent.Definition{
+		Model: nativeToolWorkflowModel{model},
+		Tools: []loop.Tool{loop.NewEchoTool()},
+		Prompt: func(context.Context, agent.RunInput) (gaictx.PromptBuilder, error) {
+			return builder, nil
+		},
+	})
+
+	workflow, err := assistant.NewRun(context.Background(), textRunInput("use echo"))
+	if err != nil {
+		t.Fatalf("NewRun failed: %v", err)
+	}
+	if len(builder.ContextSources) != 1 || builder.ContextSources[0].Name() != "application_context" {
+		t.Fatalf("native tool model added prompt tool protocol: %+v", builder.ContextSources)
+	}
+
+	consumed := consumeWorkflow(t, workflow)
+	if len(consumed.errs) != 0 {
+		t.Fatalf("workflow errors: %v", consumed.errs)
+	}
+	requests := model.Requests()
+	if len(requests) != 1 {
+		t.Fatalf("model received %d requests, want 1", len(requests))
+	}
+	if len(requests[0].Tools) != 1 || requests[0].Tools[0].Name != "echo" {
+		t.Fatalf("native tool model request did not include tool definition: %+v", requests[0])
+	}
+	if strings.Contains(requests[0].Prompt, `{"type":"function","name":"<tool-name>","arguments":{...}}`) {
+		t.Fatalf("native tool model request included prompt tool protocol:\n%s", requests[0].Prompt)
 	}
 }
 

--- a/ai/anthropic/model.go
+++ b/ai/anthropic/model.go
@@ -28,9 +28,11 @@ type Model struct {
 }
 
 var _ ai.Model = (*Model)(nil)
+var _ ai.NativeToolModel = (*Model)(nil)
 
-func (m *Model) Name() string { return m.name }
-func (m *Model) Close() error { return nil }
+func (m *Model) Name() string      { return m.name }
+func (m *Model) NativeTools() bool { return true }
+func (m *Model) Close() error      { return nil }
 func (m *Model) Tokenizer() ai.Tokenizer {
 	return &Tokenizer{modelName: m.name, client: m.client, debug: m.debug}
 }

--- a/ai/gemini/model.go
+++ b/ai/gemini/model.go
@@ -25,10 +25,13 @@ type Model struct {
 }
 
 var _ ai.Model = (*Model)(nil)
+var _ ai.NativeToolModel = (*Model)(nil)
 
 func (m *Model) Name() string {
 	return m.name
 }
+
+func (m *Model) NativeTools() bool { return true }
 
 func (m *Model) Tokenizer() ai.Tokenizer {
 	return &Tokenizer{

--- a/ai/mistral/model.go
+++ b/ai/mistral/model.go
@@ -25,10 +25,13 @@ type Model struct {
 }
 
 var _ ai.Model = (*Model)(nil)
+var _ ai.NativeToolModel = (*Model)(nil)
 
 func (m *Model) Name() string {
 	return m.name
 }
+
+func (m *Model) NativeTools() bool { return true }
 
 func (m *Model) Tokenizer() ai.Tokenizer {
 	return &Tokenizer{

--- a/ai/model.go
+++ b/ai/model.go
@@ -22,8 +22,8 @@ type Model interface {
 }
 
 // NativeToolModel is optionally implemented by models that send tool
-// definitions through their provider's native tool-calling API. Agent uses it
-// to avoid adding the text-based tool protocol to those models' prompts.
+// definitions through their provider's native tool-calling API. Agent avoids
+// adding the text-based tool protocol only when NativeTools returns true.
 //
 // It is deliberately separate from Model so existing custom Model
 // implementations retain the text-based compatibility protocol by default.

--- a/ai/model.go
+++ b/ai/model.go
@@ -20,3 +20,13 @@ type Model interface {
 	// Tokenizer returns the tokenizer associated with the model.
 	Tokenizer() Tokenizer
 }
+
+// NativeToolModel is optionally implemented by models that send tool
+// definitions through their provider's native tool-calling API. Agent uses it
+// to avoid adding the text-based tool protocol to those models' prompts.
+//
+// It is deliberately separate from Model so existing custom Model
+// implementations retain the text-based compatibility protocol by default.
+type NativeToolModel interface {
+	NativeTools() bool
+}

--- a/ai/openai/model.go
+++ b/ai/openai/model.go
@@ -22,8 +22,11 @@ type Model struct {
 }
 
 var _ ai.Model = (*Model)(nil)
+var _ ai.NativeToolModel = (*Model)(nil)
 
 func (m *Model) Name() string { return m.name }
+
+func (m *Model) NativeTools() bool { return true }
 
 func (m *Model) Close() error { return nil }
 


### PR DESCRIPTION
Closes #84

Implements the first acceptance-criteria slice: built-in native-tool adapters opt into `ai.NativeToolModel`, so agents keep `AIRequest.Tools` but skip the auto-prepended text JSON tool protocol. Custom models retain the compatibility protocol by default.

Validation: `go test ./...` and `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native tool-calling support for OpenAI, Anthropic, Gemini, and Mistral models.
  * Tool definitions are now sent through supported providers’ native interfaces instead of being embedded in prompts.
  * Models without native tool support continue using the existing prompt-based tool protocol.

* **Documentation**
  * Clarified native and fallback tool-calling behavior in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces an `ai.NativeToolModel` interface that lets built-in model adapters (OpenAI, Anthropic, Gemini, Mistral) opt into native tool-calling and skip the auto-prepended text JSON tool protocol. Custom models that do not implement the interface retain the original text-protocol fallback.

- **`ai/model.go`** — adds `NativeToolModel { NativeTools() bool }`, kept intentionally separate from `Model` to preserve backward compatibility for existing custom implementations.
- **`agent/agent.go`** — gates the `tooldefinitions` prompt source on `!usesNativeTools(model)`, so native adapters receive `AIRequest.Tools` without duplicating the schema in the prompt text.
- **`agent/agent_test.go`** — adds `nativeToolWorkflowModel` / `disabledNativeToolWorkflowModel` stubs and two new tests covering both the skip and the fallback paths.

<h3>Confidence Score: 5/5</h3>

The change is well-scoped and safe to merge: it introduces an opt-in interface, gates a single prepend call on a type assertion, and all four built-in adapters carry compile-time interface checks.

The logic is a clean three-clause guard replacing a two-clause one, all four model adapters have compile-time assertions verifying the new interface, and both the native and fallback branches are covered by dedicated tests. No existing behavior is altered for models that do not implement the new interface.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ai/model.go | Adds the NativeToolModel opt-in interface; doc comment clearly explains the separation from Model for backward compatibility. |
| agent/agent.go | Short-circuits tool-protocol injection via usesNativeTools; logic is straightforward and matches the documented semantics. |
| agent/agent_test.go | Adds two test stubs and two integration tests covering both the native-tools-skips-protocol and disabled-native-tools-adds-protocol paths. |
| ai/openai/model.go | Adds compile-time NativeToolModel assertion and NativeTools() → true; no other logic changed. |
| ai/anthropic/model.go | Adds compile-time NativeToolModel assertion and NativeTools() → true; no other logic changed. |
| ai/gemini/model.go | Adds compile-time NativeToolModel assertion and NativeTools() → true; no other logic changed. |
| ai/mistral/model.go | Adds compile-time NativeToolModel assertion and NativeTools() → true; no other logic changed. |
| README.md | Documentation updated to accurately describe native vs. fallback tool-calling behavior. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[agent.newLoop called] --> B{len Tools > 0?}
    B -- No --> F[Skip tool setup]
    B -- Yes --> C{usesNativeTools?}
    C -- Yes --> D[Tools passed via AIRequest.Tools\nNo text protocol added to prompt]
    C -- No --> E{hasContextSource tool_definitions?}
    E -- Yes --> G[Preserve existing text protocol\nNo duplication]
    E -- No --> H[Prepend tool_definitions\ntext protocol to prompt]
    D --> I[loop.New created]
    G --> I
    H --> I
    F --> I
```
</details>

<sub>Reviews (3): Last reviewed commit: ["docs: clarify native tool fallback behav..."](https://github.com/lace-ai/gai/commit/bfd129080d78bcd0ff286f5782504fee8525cf2c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47396353)</sub>

<!-- /greptile_comment -->