### PR TITLE
fix(agent): use ModelDescriber for tool protocol selection

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -43,11 +43,12 @@ type Definition struct {
 	Name string
 	// Model performs the agent's model calls.
 	Model ai.Model
-	// Tools are available to the model during loop execution. Unless the model
-	// implements ai.NativeToolModel and NativeTools returns true, their
-	// definitions and text-based invocation protocol are added as the first
-	// prompt context source unless its builder already contains a
-	// tool_definitions source.
+	// Tools are available to the model during loop execution. When the model's
+	// ai.ModelDescriber descriptor reports native tools are supported, their
+	// definitions and text-based invocation protocol are not added to the
+	// prompt. Models without a descriptor use ai.NativeToolModel as a legacy
+	// fallback. Otherwise, the protocol is added as the first prompt context
+	// source unless its builder already contains a tool_definitions source.
 	Tools []loop.Tool
 	// ToolDefinitionOptions configure the auto-prepended tool-definitions prompt
 	// source used for Tools.
@@ -180,6 +181,9 @@ func (a *Agent) newLoop(ctx context.Context, input RunInput) (*loop.Loop, error)
 }
 
 func usesNativeTools(model ai.Model) bool {
+	if describer, ok := model.(ai.ModelDescriber); ok {
+		return describer.Descriptor().NativeTools == ai.FeatureSupportSupported
+	}
 	native, ok := model.(ai.NativeToolModel)
 	return ok && native.NativeTools()
 }

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -182,7 +182,7 @@ func (a *Agent) newLoop(ctx context.Context, input RunInput) (*loop.Loop, error)
 
 func usesNativeTools(model ai.Model) bool {
 	if describer, ok := model.(ai.ModelDescriber); ok {
-		return describer.Descriptor().NativeTools == ai.FeatureSupportSupported
+		return describer.Descriptor().SupportsNativeTools()
 	}
 	native, ok := model.(ai.NativeToolModel)
 	return ok && native.NativeTools()

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -34,6 +34,15 @@ type disabledNativeToolWorkflowModel struct {
 
 func (disabledNativeToolWorkflowModel) NativeTools() bool { return false }
 
+type describedToolWorkflowModel struct {
+	*scriptedWorkflowModel
+	descriptor        ai.ModelDescriptor
+	legacyNativeTools bool
+}
+
+func (m describedToolWorkflowModel) Descriptor() ai.ModelDescriptor { return m.descriptor }
+func (m describedToolWorkflowModel) NativeTools() bool              { return m.legacyNativeTools }
+
 func (s testContextSource) Name() string { return s.name }
 func (s testContextSource) Function(context.Context, int) (gaictx.Part, error) {
 	return gaictx.NewTextPart(s.name), nil
@@ -251,6 +260,45 @@ func TestAgentNativeToolModelWithoutSupportAddsPromptToolProtocol(t *testing.T) 
 	}
 	if !strings.Contains(prompt, `{"type":"function","name":"<tool-name>","arguments":{...}}`) {
 		t.Fatalf("disabled native tool model prompt missing tool protocol:\n%s", prompt)
+	}
+}
+
+func TestAgentModelDescriberControlsPromptToolProtocol(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		nativeTools        ai.FeatureSupport
+		wantPromptProtocol bool
+	}{
+		{name: "supported", nativeTools: ai.FeatureSupportSupported},
+		{name: "unknown falls back", nativeTools: ai.FeatureSupportUnknown, wantPromptProtocol: true},
+		{name: "unsupported falls back", nativeTools: ai.FeatureSupportUnsupported, wantPromptProtocol: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := gaictx.New(gaictx.Definition{Renderer: &gaictx.SimpleRenderer{}})
+			assistant := agent.New(agent.Definition{
+				Model: describedToolWorkflowModel{
+					scriptedWorkflowModel: &scriptedWorkflowModel{},
+					descriptor:            ai.ModelDescriptor{NativeTools: tt.nativeTools},
+					legacyNativeTools:     true,
+				},
+				Tools: []loop.Tool{loop.NewEchoTool()},
+				Prompt: func(context.Context, agent.RunInput) (gaictx.PromptBuilder, error) {
+					return builder, nil
+				},
+			})
+
+			if _, err := assistant.NewRun(context.Background(), textRunInput("use echo")); err != nil {
+				t.Fatalf("NewRun failed: %v", err)
+			}
+			hasPromptProtocol := len(builder.ContextSources) == 1 && builder.ContextSources[0].Name() == "tool_definitions"
+			if hasPromptProtocol != tt.wantPromptProtocol {
+				t.Fatalf("prompt protocol = %t, want %t; sources: %+v", hasPromptProtocol, tt.wantPromptProtocol, builder.ContextSources)
+			}
+		})
 	}
 }
 

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -269,11 +269,12 @@ func TestAgentModelDescriberControlsPromptToolProtocol(t *testing.T) {
 	tests := []struct {
 		name               string
 		nativeTools        ai.FeatureSupport
+		legacyNativeTools  bool
 		wantPromptProtocol bool
 	}{
-		{name: "supported", nativeTools: ai.FeatureSupportSupported},
-		{name: "unknown falls back", nativeTools: ai.FeatureSupportUnknown, wantPromptProtocol: true},
-		{name: "unsupported falls back", nativeTools: ai.FeatureSupportUnsupported, wantPromptProtocol: true},
+		{name: "supported overrides legacy false", nativeTools: ai.FeatureSupportSupported},
+		{name: "unknown falls back", nativeTools: ai.FeatureSupportUnknown, legacyNativeTools: true, wantPromptProtocol: true},
+		{name: "unsupported falls back", nativeTools: ai.FeatureSupportUnsupported, legacyNativeTools: true, wantPromptProtocol: true},
 	}
 
 	for _, tt := range tests {
@@ -283,7 +284,7 @@ func TestAgentModelDescriberControlsPromptToolProtocol(t *testing.T) {
 				Model: describedToolWorkflowModel{
 					scriptedWorkflowModel: &scriptedWorkflowModel{},
 					descriptor:            ai.ModelDescriptor{NativeTools: tt.nativeTools},
-					legacyNativeTools:     true,
+					legacyNativeTools:     tt.legacyNativeTools,
 				},
 				Tools: []loop.Tool{loop.NewEchoTool()},
 				Prompt: func(context.Context, agent.RunInput) (gaictx.PromptBuilder, error) {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -273,8 +273,8 @@ func TestAgentModelDescriberControlsPromptToolProtocol(t *testing.T) {
 		wantPromptProtocol bool
 	}{
 		{name: "supported overrides legacy false", nativeTools: ai.FeatureSupportSupported},
-		{name: "unknown falls back", nativeTools: ai.FeatureSupportUnknown, legacyNativeTools: true, wantPromptProtocol: true},
-		{name: "unsupported falls back", nativeTools: ai.FeatureSupportUnsupported, legacyNativeTools: true, wantPromptProtocol: true},
+		{name: "unknown ignores legacy support", nativeTools: ai.FeatureSupportUnknown, legacyNativeTools: true, wantPromptProtocol: true},
+		{name: "unsupported ignores legacy support", nativeTools: ai.FeatureSupportUnsupported, legacyNativeTools: true, wantPromptProtocol: true},
 	}
 
 	for _, tt := range tests {

--- a/ai/model.go
+++ b/ai/model.go
@@ -21,12 +21,15 @@ type Model interface {
 	Tokenizer() Tokenizer
 }
 
-// NativeToolModel is optionally implemented by models that send tool
-// definitions through their provider's native tool-calling API. Agent avoids
-// adding the text-based tool protocol only when NativeTools returns true.
+// NativeToolModel is optionally implemented by legacy models that send tool
+// definitions through their provider's native tool-calling API. New models
+// should implement ModelDescriber and report ModelDescriptor.NativeTools
+// instead. Agent consults NativeToolModel only when ModelDescriber is absent.
 //
 // It is deliberately separate from Model so existing custom Model
 // implementations retain the text-based compatibility protocol by default.
+//
+// Deprecated: implement ModelDescriber instead.
 type NativeToolModel interface {
 	NativeTools() bool
 }

--- a/ai/model_descriptor.go
+++ b/ai/model_descriptor.go
@@ -66,6 +66,13 @@ type ModelDescriptor struct {
 	Tokenizer        TokenizerDescriptor
 }
 
+// SupportsNativeTools reports whether native tool calling is known to be
+// supported. Unknown capability is intentionally treated as unsupported so
+// callers can retain the text-based tool protocol as a compatibility fallback.
+func (d ModelDescriptor) SupportsNativeTools() bool {
+	return d.NativeTools == FeatureSupportSupported
+}
+
 // Copy returns an independent copy of d. It is provided so callers need not
 // rely on the descriptor's current value-only representation.
 func (d ModelDescriptor) Copy() ModelDescriptor {

--- a/ai/model_descriptor_test.go
+++ b/ai/model_descriptor_test.go
@@ -16,6 +16,26 @@ func TestModelDescriptorZeroValueIsUnknownAndPermitsRequests(t *testing.T) {
 	}
 }
 
+func TestModelDescriptorSupportsNativeTools(t *testing.T) {
+	tests := []struct {
+		name    string
+		support FeatureSupport
+		want    bool
+	}{
+		{name: "supported", support: FeatureSupportSupported, want: true},
+		{name: "unknown", support: FeatureSupportUnknown},
+		{name: "unsupported", support: FeatureSupportUnsupported},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := (ModelDescriptor{NativeTools: tt.support}).SupportsNativeTools(); got != tt.want {
+				t.Fatalf("SupportsNativeTools() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestModelDescriptorCopy(t *testing.T) {
 	d := ModelDescriptor{Model: "test", ToolCalling: FeatureSupportSupported, NativeMessages: FeatureSupportSupported, ToolChoiceModes: []ToolChoiceMode{ToolChoiceAuto}, ReasoningEfforts: []ReasoningEffort{ReasoningEffortLow}, Tokenizer: TokenizerDescriptor{Available: FeatureSupportSupported, Fidelity: TokenizerFidelityExact}}
 	copy := d.Copy()


### PR DESCRIPTION
Closes #99

## Summary
- make `ModelDescriber.Descriptor().NativeTools` canonical for automatic prompt tool-protocol selection
- keep `NativeToolModel` as a deprecated fallback only when no descriptor is available
- cover descriptor supported/unknown/unsupported behavior, including disagreement with the legacy interface

## Validation
- `go test ./...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of models that support native tools.
  * Models with known native-tool support no longer receive unnecessary text-based tool instructions.
  * Preserved compatibility with existing models that use the legacy tool-support mechanism.

* **Documentation**
  * Clarified how native-tool support is determined for new and legacy models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `ModelDescriber` as the canonical source for determining native tool support in the agent loop, with `NativeToolModel` demoted to a deprecated legacy fallback consulted only when no descriptor is present. The change is additive and conservative: `FeatureSupportUnknown` is deliberately treated as unsupported so the text-based tool protocol remains as a compatibility fallback.

- `usesNativeTools` in `agent/agent.go` now type-asserts to `ai.ModelDescriber` first; if the model implements it, `SupportsNativeTools()` is the sole authority and `NativeToolModel` is ignored entirely.
- A new `SupportsNativeTools()` helper on `ModelDescriptor` encapsulates the "Unknown → false" default, keeping call sites clean.
- `NativeToolModel` is marked `// Deprecated:` in `ai/model.go` and both the new descriptor path and the legacy fallback are covered by new table-driven tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is conservative, additive, and well-tested with no regressions for legacy models.

The priority ordering in usesNativeTools is correct: ModelDescriber is checked first, and the NativeToolModel fallback fires only when no descriptor is present. The Unknown → false default in SupportsNativeTools keeps the text-based protocol active for any model that has not explicitly declared support, which is the safe failure mode. Tests cover all three FeatureSupport states and the disagreement scenario between the two interfaces.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agent/agent.go | Adds ModelDescriber check at the top of usesNativeTools; logic is correct and the fallback ordering is safe. |
| agent/agent_test.go | Adds describedToolWorkflowModel and a table-driven test covering Supported/Unknown/Unsupported states and legacy-disagreement cases. |
| ai/model.go | NativeToolModel doc comment updated with deprecation notice and guidance to use ModelDescriber instead. |
| ai/model_descriptor.go | Adds SupportsNativeTools() helper that returns true only for FeatureSupportSupported; zero value (Unknown) is conservatively false. |
| ai/model_descriptor_test.go | Table-driven test for all three FeatureSupport values against SupportsNativeTools(); straightforward and complete. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[usesNativeTools called] --> B{implements ModelDescriber?}
    B -- Yes --> C[call SupportsNativeTools]
    C --> D{NativeTools == Supported?}
    D -- Yes --> E[return true - skip text protocol]
    D -- No --> F[return false - add text protocol]
    B -- No --> G{implements NativeToolModel?}
    G -- Yes --> H{NativeTools returns true?}
    H -- Yes --> E
    H -- No --> F
    G -- No --> F
```
</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(ai): centralize native tool cap..."](https://github.com/lace-ai/gai/commit/a88ee5512071fba32d998c0430010b34b2b1cba8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49014428)</sub>

<!-- /greptile_comment -->