### PR TITLE
fix(loop): omit native tools for text transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,11 +735,18 @@ Tool calls are expected to arrive as JSON with this shape:
 ```
 
 Tool call IDs are generated internally by the runtime and are not model-controlled.
-Models whose `ai.NativeToolModel.NativeTools()` method returns `true` receive
-tool definitions through `AIRequest.Tools` without the prompt-rendered JSON
-tool protocol. Models that do not report native support retain that text
-protocol as a compatibility fallback. A prompt builder with an existing
-`tool_definitions` source also explicitly preserves the text protocol.
+`Loop.Tools` always holds executable runtime tools. `Loop.ToolTransport` controls
+only whether those tools are serialized into provider-native `AIRequest.Tools`;
+direct `loop.New` defaults to `loop.ToolTransportNative`, while
+`loop.ToolTransportText` retains executable tools but omits provider-native
+definitions for a prompt-rendered protocol.
+
+For `agent.Definition`, a model descriptor is authoritative: native transport is
+used only when `Descriptor().NativeTools` is supported. Models without a
+descriptor use the deprecated `ai.NativeToolModel` compatibility fallback.
+Text transport adds the prompt-rendered JSON tool protocol unless the prompt
+builder already has a `tool_definitions` source; an existing source can also
+intentionally add textual instructions to a native model.
 
 </details>
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -144,7 +144,8 @@ func (a *Agent) newLoop(ctx context.Context, input RunInput) (*loop.Loop, error)
 		return nil, loop.ErrPromptNotConfigured
 	}
 	promptBuilder.SetInput(input.Prompt)
-	if len(a.def.Tools) > 0 && !usesNativeTools(a.def.Model) && !hasContextSource(promptBuilder, "tool_definitions") {
+	nativeTools := usesNativeTools(a.def.Model)
+	if len(a.def.Tools) > 0 && !nativeTools && !hasContextSource(promptBuilder, "tool_definitions") {
 		toolSource, err := tooldefinitions.New(nil, a.def.Tools, a.def.DebugSink, a.def.ToolDefinitionOptions...)
 		if err != nil {
 			return nil, err
@@ -164,6 +165,9 @@ func (a *Agent) newLoop(ctx context.Context, input RunInput) (*loop.Loop, error)
 	}
 
 	l := loop.New(a.def.Model, a.def.Tools, promptBuilder, a.def.ToolResponseProcessor)
+	if !nativeTools {
+		l.ToolTransport = loop.ToolTransportText
+	}
 	if a.def.Limits.MaxLoopIterations > 0 {
 		l.MaxLoopIterations = a.def.Limits.MaxLoopIterations
 	}

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -42,6 +42,15 @@ type describedToolWorkflowModel struct {
 
 func (m describedToolWorkflowModel) Descriptor() ai.ModelDescriptor { return m.descriptor }
 func (m describedToolWorkflowModel) NativeTools() bool              { return m.legacyNativeTools }
+func (m describedToolWorkflowModel) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.Token {
+	if err := m.descriptor.ValidateRequest(req); err != nil {
+		out := make(chan ai.Token, 1)
+		out <- ai.Token{Type: ai.TokenTypeErr, Err: err}
+		close(out)
+		return out
+	}
+	return m.scriptedWorkflowModel.GenerateStream(ctx, req)
+}
 
 func (s testContextSource) Name() string { return s.name }
 func (s testContextSource) Function(context.Context, int) (gaictx.Part, error) {
@@ -298,6 +307,69 @@ func TestAgentModelDescriberControlsPromptToolProtocol(t *testing.T) {
 			hasPromptProtocol := len(builder.ContextSources) == 1 && builder.ContextSources[0].Name() == "tool_definitions"
 			if hasPromptProtocol != tt.wantPromptProtocol {
 				t.Fatalf("prompt protocol = %t, want %t; sources: %+v", hasPromptProtocol, tt.wantPromptProtocol, builder.ContextSources)
+			}
+		})
+	}
+}
+
+func TestAgentResolvesToolTransportForPromptAndRequest(t *testing.T) {
+	tests := []struct {
+		name               string
+		described          bool
+		nativeTools        ai.FeatureSupport
+		legacyNativeTools  bool
+		wantPromptProtocol bool
+		wantRequestTools   bool
+	}{
+		{name: "descriptor supported", described: true, nativeTools: ai.FeatureSupportSupported, wantRequestTools: true},
+		{name: "descriptor unknown", described: true, nativeTools: ai.FeatureSupportUnknown, legacyNativeTools: true, wantPromptProtocol: true},
+		{name: "descriptor unsupported", described: true, nativeTools: ai.FeatureSupportUnsupported, legacyNativeTools: true, wantPromptProtocol: true},
+		{name: "legacy native model", legacyNativeTools: true, wantRequestTools: true},
+		{name: "legacy text model", wantPromptProtocol: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := gaictx.New(gaictx.Definition{Renderer: &gaictx.SimpleRenderer{}})
+			model := &scriptedWorkflowModel{scripts: [][]ai.Token{{}}}
+			var configuredModel ai.Model = model
+			if tt.described {
+				configuredModel = describedToolWorkflowModel{
+					scriptedWorkflowModel: model,
+					descriptor:            ai.ModelDescriptor{NativeTools: tt.nativeTools},
+					legacyNativeTools:     tt.legacyNativeTools,
+				}
+			} else if tt.legacyNativeTools {
+				configuredModel = nativeToolWorkflowModel{model}
+			}
+
+			assistant := agent.New(agent.Definition{
+				Model: configuredModel,
+				Tools: []loop.Tool{loop.NewEchoTool()},
+				Prompt: func(context.Context, agent.RunInput) (gaictx.PromptBuilder, error) {
+					return builder, nil
+				},
+			})
+			workflow, err := assistant.NewRun(context.Background(), textRunInput("use echo"))
+			if err != nil {
+				t.Fatalf("NewRun failed: %v", err)
+			}
+			consumed := consumeWorkflow(t, workflow)
+			if len(consumed.errs) != 0 {
+				t.Fatalf("workflow errors: %v", consumed.errs)
+			}
+			if got := len(builder.ContextSources) == 1 && builder.ContextSources[0].Name() == "tool_definitions"; got != tt.wantPromptProtocol {
+				t.Fatalf("prompt protocol = %t, want %t; sources: %+v", got, tt.wantPromptProtocol, builder.ContextSources)
+			}
+			requests := model.Requests()
+			if len(requests) != 1 {
+				t.Fatalf("requests = %d, want 1", len(requests))
+			}
+			if got := len(requests[0].Tools) > 0; got != tt.wantRequestTools {
+				t.Fatalf("request tools = %#v, want present=%t", requests[0].Tools, tt.wantRequestTools)
+			}
+			if len(workflow.Loop.Tools) != 1 || workflow.Loop.Tools[0].Name() != "echo" {
+				t.Fatalf("loop lost executable tools: %#v", workflow.Loop.Tools)
 			}
 		})
 	}

--- a/agent/e2e_test.go
+++ b/agent/e2e_test.go
@@ -167,15 +167,18 @@ func TestAgentWorkflowEndToEndWithToolCall(t *testing.T) {
 	if len(requests) != 2 {
 		t.Fatalf("expected two model requests, got %d", len(requests))
 	}
-	if requests[0].MaxTokens != 64 || len(requests[0].Tools) != 1 || requests[0].Tools[0].Name != "echo" {
-		t.Fatalf("first request did not include limits and tools: %+v", requests[0])
+	if requests[0].MaxTokens != 64 || len(requests[0].Tools) != 0 {
+		t.Fatalf("first request did not preserve limits or text tool transport: %+v", requests[0])
+	}
+	if !strings.Contains(requests[0].Prompt, `{"type":"function","name":"<tool-name>","arguments":{...}}`) {
+		t.Fatalf("first request did not include the text tool protocol:\n%s", requests[0].Prompt)
 	}
 	for index, request := range requests {
 		if request.ResponseFormat.Type != ai.ResponseFormatJSONSchema || request.ResponseFormat.Name != "answer" || string(request.ResponseFormat.Schema) != expectedSchema {
 			t.Fatalf("request %d did not preserve response format: %+v", index, request.ResponseFormat)
 		}
-		if len(request.Tools) != 1 || request.Tools[0].Name != "echo" {
-			t.Fatalf("request %d did not preserve native tools: %+v", index, request.Tools)
+		if len(request.Tools) != 0 {
+			t.Fatalf("request %d sent provider-native tools during text transport: %+v", index, request.Tools)
 		}
 	}
 	if !strings.Contains(requests[1].Prompt, "tool res: tool says hi") {

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -15,6 +15,19 @@ const (
 	defaultRetryCount        = 3
 )
 
+// ToolTransportMode controls whether a loop sends tool definitions through the
+// provider-native AIRequest.Tools field. It does not affect Loop.Tools, which
+// always remains available to resolve and execute tool calls.
+type ToolTransportMode uint8
+
+const (
+	// ToolTransportNative sends Loop.Tools as AIRequest.Tools. This is the
+	// default to preserve direct loop.New compatibility.
+	ToolTransportNative ToolTransportMode = iota
+	// ToolTransportText omits AIRequest.Tools for prompt-rendered tool protocols.
+	ToolTransportText
+)
+
 // ToolResponseProcessor can inspect or modify a tool response before the loop
 // records it and builds the next prompt. Implementations must be safe for
 // concurrent use.
@@ -35,6 +48,9 @@ type Loop struct {
 	Model ai.Model
 	// Tools contains the functions available to the model.
 	Tools []Tool
+	// ToolTransport controls whether Tools are serialized into AIRequest.Tools.
+	// The default is ToolTransportNative; Tools remain executable in either mode.
+	ToolTransport ToolTransportMode
 	// MaxLoopIterations limits model/tool interaction rounds.
 	MaxLoopIterations int
 	// MaxTokens limits model output for each generation request.
@@ -174,14 +190,20 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 			return
 		}
 
-		toolDefinitions, err := ToolDefinitions(l.Tools)
-		if err != nil {
-			if cancelErr := cancellationError(ctx, err); cancelErr != nil {
-				sendLoopCanceled(ctx, events, runState, cancelErr)
+		var (
+			toolDefinitions []ai.ToolDefinition
+			err             error
+		)
+		if l.ToolTransport == ToolTransportNative {
+			toolDefinitions, err = ToolDefinitions(l.Tools)
+			if err != nil {
+				if cancelErr := cancellationError(ctx, err); cancelErr != nil {
+					sendLoopCanceled(ctx, events, runState, cancelErr)
+					return
+				}
+				sendLoopError(ctx, events, runState, err)
 				return
 			}
-			sendLoopError(ctx, events, runState, err)
-			return
 		}
 
 		_, err = l.PromptBuilder.BuildContext(ctx)

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -989,6 +989,39 @@ func TestLoopFallsBackToBuildPromptEveryIteration(t *testing.T) {
 	}
 }
 
+func TestLoopToolTransportControlsProviderToolDefinitions(t *testing.T) {
+	tests := []struct {
+		name      string
+		transport loop.ToolTransportMode
+		wantTools bool
+	}{
+		{name: "default native transport", wantTools: true},
+		{name: "text transport", transport: loop.ToolTransportText},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := &scriptedStreamModel{sequences: [][]ai.Token{{{Type: ai.TokenTypeText, Text: "done"}}}}
+			l := loop.New(model, []loop.Tool{loop.NewEchoTool()}, testPromptBuilder(), nil)
+			l.ToolTransport = tt.transport
+
+			if err := loopError(collectLoopEvents(t, l, context.Background())); err != nil {
+				t.Fatalf("unexpected loop error: %v", err)
+			}
+			requests := model.Requests()
+			if len(requests) != 1 {
+				t.Fatalf("requests = %d, want 1", len(requests))
+			}
+			if got := len(requests[0].Tools) > 0; got != tt.wantTools {
+				t.Fatalf("request tools = %#v, want present=%t", requests[0].Tools, tt.wantTools)
+			}
+			if len(l.Tools) != 1 || l.Tools[0].Name() != "echo" {
+				t.Fatalf("loop lost executable tools: %#v", l.Tools)
+			}
+		})
+	}
+}
+
 func TestLoopNativeHistoryIncludesBaseRequestWithoutRenderedHistory(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #102

## Summary
- resolve tool transport once in `agent.NewRun` and omit `AIRequest.Tools` for textual fallback
- preserve executable `Loop.Tools` and direct `loop.New` native-default compatibility
- cover descriptor/legacy transport selection and document the distinction

## Validation
- `go test ./...`
- `git diff --check`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where `AIRequest.Tools` was always populated in the loop — even for text-transport models — causing those models to receive tool definitions through both the rendered-prompt text protocol and the provider-native `AIRequest.Tools` field simultaneously. It introduces `ToolTransportMode` to gate the `ToolDefinitions` call in `loop.Run`, while keeping `Loop.Tools` executable in both modes.

- **`loop/loop.go`**: Adds `ToolTransportMode` (`ToolTransportNative` / `ToolTransportText`) and makes `ToolDefinitions` serialization conditional on transport mode; `ToolTransportNative` is the zero-value default, preserving backward compatibility for direct `loop.New` callers.
- **`agent/agent.go`**: Resolves the transport mode once per `NewRun` via `usesNativeTools`, injecting `ToolTransportText` into the loop when the model's descriptor (or legacy `NativeToolModel`) indicates text-only support; previously the prompt tool-definitions source was added correctly but `AIRequest.Tools` was still populated.
- Tests cover descriptor-authoritative selection, legacy fallback, and the end-to-end text-transport request shape.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted bug fix with no breaking surface for existing consumers.

The core fix (gating ToolDefinitions on ToolTransport) is contained to a single conditional in loop.Run. ToolTransportNative is the zero-value iota, so every existing direct loop.New caller retains the old behaviour without any change. The agent-layer change sets ToolTransportText only when usesNativeTools is already returning false, which was already controlling prompt injection — so the two code paths are now consistently coupled. Tests cover the descriptor-wins-over-legacy case, both transport modes end-to-end, and verify Loop.Tools remains executable in either mode.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| loop/loop.go | Adds ToolTransportMode enum and gates ToolDefinitions serialization on transport mode; ToolTransportNative is the zero-value default preserving full backward compatibility for existing loop.New callers. |
| agent/agent.go | Resolves transport mode once per run using usesNativeTools, sets ToolTransportText on the loop when the model is text-only; correctly aligns prompt source injection and AIRequest.Tools population so they are no longer both set for text-transport models. |
| agent/agent_test.go | Adds GenerateStream override to describedToolWorkflowModel for request validation, and a table-driven test covering all descriptor/legacy transport combinations including descriptor-wins-over-legacy behaviour. |
| agent/e2e_test.go | Updates end-to-end assertions from expecting native tools in AIRequest.Tools to verifying they are absent and the text protocol string is present in the prompt instead. |
| loop/loop_test.go | Adds a table-driven test for ToolTransport modes, confirming AIRequest.Tools is populated only for native transport while Loop.Tools stays executable in both modes. |
| README.md | Updates documentation to describe the Loop.Tools / ToolTransport distinction and the descriptor-authoritative vs legacy-fallback transport selection logic. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["agent.NewRun"] --> B["usesNativeTools(model)"]
    B --> C{ModelDescriber?}
    C -- yes --> D["Descriptor().SupportsNativeTools()"]
    C -- no --> E{NativeToolModel?}
    E -- yes + NativeTools() --> F["nativeTools = true"]
    E -- no / false --> G["nativeTools = false"]
    D -- FeatureSupportSupported --> F
    D -- Unknown / Unsupported --> G
    F --> H["Skip prompt tool_definitions source"]
    G --> I["Prepend tool_definitions to prompt (text protocol)"]
    H --> J["loop.New → ToolTransport = ToolTransportNative (default)"]
    I --> K["loop.New → l.ToolTransport = ToolTransportText"]
    J --> L["loop.Run: ToolDefinitions called, AIRequest.Tools populated"]
    K --> M["loop.Run: ToolDefinitions skipped, AIRequest.Tools = nil"]
    L --> N["Loop.Tools always present (tool execution unchanged)"]
    M --> N
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(loop): omit native tools for text tr..."](https://github.com/lace-ai/gai/commit/a6ca8e6cd01520baa9403108d1023ef5c95d5dc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49168986)</sub>

<!-- /greptile_comment -->