### PR TITLE
fix: render native initial requests once

### DIFF
--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -72,8 +72,8 @@ func (b *testPromptBuilder) BuildPrompt(ctx context.Context, conv gaictx.Convers
 	return b.prompt, nil
 }
 
-func (b *testPromptBuilder) BuildMessages(ctx context.Context, conv gaictx.Conversation) ([]ai.RequestMessage, error) {
-	return []ai.RequestMessage{{Role: ai.RequestMessageRoleUser, Text: b.prompt}}, nil
+func (b *testPromptBuilder) BuildRequest(ctx context.Context, conv gaictx.Conversation) (string, []ai.RequestMessage, error) {
+	return b.prompt, []ai.RequestMessage{{Role: ai.RequestMessageRoleUser, Text: b.prompt}}, nil
 }
 
 func (b *testPromptBuilder) Input() gaictx.PromptInput {

--- a/context/prompt_builder.go
+++ b/context/prompt_builder.go
@@ -39,11 +39,11 @@ type PromptBuilder interface {
 	SetInput(input PromptInput)
 }
 
-// NativeMessageBuilder optionally exposes provider-neutral request messages.
-// PromptBuilder implementations that do not provide it continue to use the
-// rendered prompt as their request input.
+// NativeMessageBuilder optionally constructs both representations of a model
+// request. PromptBuilder implementations that do not provide it continue to
+// use the rendered prompt as their request input.
 type NativeMessageBuilder interface {
-	BuildMessages(ctx context.Context, conv Conversation) ([]ai.RequestMessage, error)
+	BuildRequest(ctx context.Context, conv Conversation) (string, []ai.RequestMessage, error)
 }
 
 // NativeConversation exposes provider-neutral conversation history alongside
@@ -314,19 +314,29 @@ type basePromptConversation struct{}
 
 func (basePromptConversation) Messages() []Message { return nil }
 
-// BuildMessages builds the provider-neutral request messages for conv. The
-// initial user message is the prompt without rendered conversation history;
-// native conversation entries follow when conv provides them.
-func (b *Builder) BuildMessages(ctx context.Context, conv Conversation) ([]ai.RequestMessage, error) {
+// BuildRequest builds both the compatibility prompt and provider-neutral
+// messages for conv. With no native history, the native user message reuses the
+// compatibility prompt so render callbacks fire only once. Once native history
+// exists, the native user message remains the history-free base prompt.
+func (b *Builder) BuildRequest(ctx context.Context, conv Conversation) (string, []ai.RequestMessage, error) {
+	prompt, err := b.BuildPrompt(ctx, conv)
+	if err != nil {
+		return "", nil, err
+	}
+	var nativeMessages []ai.RequestMessage
+	if native, ok := conv.(NativeConversation); ok {
+		nativeMessages = native.NativeMessages()
+	}
+	if len(nativeMessages) == 0 {
+		return prompt, []ai.RequestMessage{{Role: ai.RequestMessageRoleUser, Text: prompt}}, nil
+	}
 	basePrompt, err := b.BuildPrompt(ctx, basePromptConversation{})
 	if err != nil {
-		return nil, err
+		return "", nil, err
 	}
 	messages := []ai.RequestMessage{{Role: ai.RequestMessageRoleUser, Text: basePrompt}}
-	if native, ok := conv.(NativeConversation); ok {
-		messages = append(messages, native.NativeMessages()...)
-	}
-	return messages, nil
+	messages = append(messages, nativeMessages...)
+	return prompt, messages, nil
 }
 
 func (b *Builder) Input() PromptInput {

--- a/context/prompt_builder_test.go
+++ b/context/prompt_builder_test.go
@@ -106,18 +106,21 @@ func (c nativeMessageConversation) NativeMessages() []ai.RequestMessage {
 	return c.nativeMessages
 }
 
-func TestBuildMessagesCombinesBasePromptAndNativeConversation(t *testing.T) {
+func TestBuildRequestCombinesPromptAndNativeConversation(t *testing.T) {
 	t.Parallel()
 
 	builder := New(Definition{
 		SystemInstructions: []Part{NewTextPart("system")},
 		PromptInput:        PromptInput{User: NewTextContent("question")},
 	})
-	messages, err := builder.BuildMessages(context.Background(), nativeMessageConversation{
+	prompt, messages, err := builder.BuildRequest(context.Background(), nativeMessageConversation{
 		nativeMessages: []ai.RequestMessage{{Role: ai.RequestMessageRoleAssistant, Text: "answer"}},
 	})
 	if err != nil {
-		t.Fatalf("BuildMessages failed: %v", err)
+		t.Fatalf("BuildRequest failed: %v", err)
+	}
+	if !strings.Contains(prompt, "system") || !strings.Contains(prompt, "question") {
+		t.Fatalf("compatibility prompt = %q", prompt)
 	}
 	if len(messages) != 2 {
 		t.Fatalf("messages = %#v, want base user and native assistant messages", messages)

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -233,7 +233,13 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 					return
 				}
 
-				prompt, err := l.PromptBuilder.BuildPrompt(iterCtx, l)
+				var prompt string
+				var nativeMessages []ai.RequestMessage
+				if builder, ok := l.PromptBuilder.(gaictx.NativeMessageBuilder); ok {
+					prompt, nativeMessages, err = builder.BuildRequest(iterCtx, l)
+				} else {
+					prompt, err = l.PromptBuilder.BuildPrompt(iterCtx, l)
+				}
 				if err != nil {
 					if cancelErr := cancellationError(iterCtx, err); cancelErr != nil {
 						sendAttemptCanceled(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, cancelErr)
@@ -250,23 +256,7 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 				}
 
 				request := renderedPromptRequest(prompt, l.MaxTokens, toolDefinitions, l.ResponseFormat, l.Reasoning)
-				if builder, ok := l.PromptBuilder.(gaictx.NativeMessageBuilder); ok {
-					request.Messages, err = builder.BuildMessages(iterCtx, l)
-					if err != nil {
-						if cancelErr := cancellationError(iterCtx, err); cancelErr != nil {
-							sendAttemptCanceled(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, cancelErr)
-							cancel()
-							iterState.markCanceled(cancelErr)
-							iterState.finish(nil)
-							return
-						}
-						iterationErr = fmt.Errorf("%w: %w", ErrBuildPrompt, err)
-						sendAttemptError(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, iterationErr)
-						cancel()
-						iterState.finish(iterationErr)
-						return
-					}
-				}
+				request.Messages = nativeMessages
 
 				tokens := l.Model.GenerateStream(iterCtx, request)
 

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -144,23 +144,36 @@ func (b *stubPromptBuilder) BuildPrompt(ctx context.Context, conv gaictx.Convers
 	return prompt.String(), nil
 }
 
-func (b *stubPromptBuilder) BuildMessages(ctx context.Context, conv gaictx.Conversation) ([]ai.RequestMessage, error) {
-	return testNativeMessages(ctx, b, conv)
+func (b *stubPromptBuilder) BuildRequest(ctx context.Context, conv gaictx.Conversation) (string, []ai.RequestMessage, error) {
+	prompt, err := b.BuildPrompt(ctx, conv)
+	if err != nil {
+		return "", nil, err
+	}
+	messages, err := testNativeMessages(ctx, b, conv, prompt)
+	if err != nil {
+		return "", nil, err
+	}
+	return prompt, messages, nil
 }
 
 type emptyPromptConversation struct{}
 
 func (emptyPromptConversation) Messages() []gaictx.Message { return nil }
 
-func testNativeMessages(ctx context.Context, builder gaictx.PromptBuilder, conv gaictx.Conversation) ([]ai.RequestMessage, error) {
+func testNativeMessages(ctx context.Context, builder gaictx.PromptBuilder, conv gaictx.Conversation, prompt string) ([]ai.RequestMessage, error) {
+	var nativeMessages []ai.RequestMessage
+	if native, ok := conv.(gaictx.NativeConversation); ok {
+		nativeMessages = native.NativeMessages()
+	}
+	if len(nativeMessages) == 0 {
+		return []ai.RequestMessage{{Role: ai.RequestMessageRoleUser, Text: prompt}}, nil
+	}
 	base, err := builder.BuildPrompt(ctx, emptyPromptConversation{})
 	if err != nil {
 		return nil, err
 	}
 	messages := []ai.RequestMessage{{Role: ai.RequestMessageRoleUser, Text: base}}
-	if native, ok := conv.(gaictx.NativeConversation); ok {
-		messages = append(messages, native.NativeMessages()...)
-	}
+	messages = append(messages, nativeMessages...)
 	return messages, nil
 }
 
@@ -1025,6 +1038,46 @@ func TestLoopNativeHistoryIncludesBaseRequestWithoutRenderedHistory(t *testing.T
 	}
 	if !strings.Contains(second.Prompt, "payload") {
 		t.Fatalf("complete rendered fallback omitted tool history: %q", second.Prompt)
+	}
+}
+
+func TestLoopNativeRequestRendersInitialPromptOnce(t *testing.T) {
+	t.Parallel()
+
+	model := &scriptedStreamModel{sequences: [][]ai.Token{
+		{{Type: ai.TokenTypeToolCall, ToolCall: &ai.ToolCall{ID: "call-1", Type: "function", Name: "echo", Args: json.RawMessage(`{"text":"payload"}`)}}},
+		{{Type: ai.TokenTypeText, Data: []byte("done")}},
+	}}
+	renderer := &gaictx.SimpleRenderer{}
+	var rendered []string
+	if err := renderer.SetRenderResultCallback(context.Background(), func(_ []gaictx.Part, prompt string) {
+		rendered = append(rendered, prompt)
+	}); err != nil {
+		t.Fatalf("SetRenderResultCallback failed: %v", err)
+	}
+	promptBuilder := gaictx.New(gaictx.Definition{
+		Renderer:           renderer,
+		SystemInstructions: []gaictx.Part{gaictx.NewTextPart("system")},
+		PromptInput:        gaictx.PromptInput{User: gaictx.NewTextContent("user")},
+	})
+	l := loop.New(model, []loop.Tool{loop.NewEchoTool()}, promptBuilder, nil)
+	l.MaxLoopIterations = 3
+
+	if err := loopError(collectLoopEvents(t, l, context.Background())); err != nil {
+		t.Fatalf("unexpected loop error: %v", err)
+	}
+	if len(rendered) != 3 {
+		t.Fatalf("render callbacks = %d, want one initial render and two distinct follow-up renders: %#v", len(rendered), rendered)
+	}
+	if rendered[0] != model.Requests()[0].Prompt {
+		t.Fatalf("initial callback prompt = %q, want request prompt %q", rendered[0], model.Requests()[0].Prompt)
+	}
+	requests := model.Requests()
+	if len(requests) != 2 || len(requests[0].Messages) != 1 || requests[0].Messages[0].Text != requests[0].Prompt {
+		t.Fatalf("initial native request = %#v, want its sole native message to reuse the compatibility prompt", requests)
+	}
+	if !strings.Contains(requests[1].Prompt, "payload") || strings.Contains(requests[1].Messages[0].Text, "payload") {
+		t.Fatalf("follow-up request must retain rendered fallback history and separate native base: %#v", requests[1])
 	}
 }
 


### PR DESCRIPTION
Fixes #98.

- replace the native-builder contract with `BuildRequest`, returning the compatibility prompt and provider-native messages together
- reuse the initial compatibility render for the first native user message
- preserve a history-free native base plus assistant/tool messages on follow-up iterations
- add callback regression coverage for initial and tool-follow-up requests

Validation: `go test ./... -count=1`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a double-render bug (issue #98) where `BuildPrompt` was called twice on the initial model request when the `NativeMessageBuilder` path was active. It replaces the `BuildMessages` contract with `BuildRequest`, which returns both the compatibility prompt and provider-native messages in a single call.

- **`NativeMessageBuilder.BuildRequest`** now returns `(string, []ai.RequestMessage, error)` so the loop only needs one build call per attempt; on the initial request (no native history) the native user message is set to the already-rendered compatibility prompt, eliminating the redundant render.
- **`loop.go`** consolidates the two-step `BuildPrompt` + `BuildMessages` into a single `BuildRequest` (or `BuildPrompt` for non-native builders) with unified error handling; follow-up iterations still call `BuildPrompt` twice internally — once for the full compatibility prompt and once for the history-free native base message.
- **New test `TestLoopNativeRequestRendersInitialPromptOnce`** verifies both the single-render invariant on the first request and the correct separation of the base native message from the rendered fallback history on tool-follow-up requests.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the change is well-scoped, all existing callers of the old interface have been updated, and the new test directly exercises both the initial and tool-follow-up paths.

The refactor is straightforward: the two-step build in the loop is collapsed into one, and the decision about whether to re-render a base prompt is moved inside BuildRequest where it has full context. The nil-assignment of nativeMessages when NativeMessageBuilder is absent is a no-op (same as the zero-value default). Retry behaviour is unchanged because l.Iterations is not mutated between attempts. The new regression test pins the exact render-callback count and the native-vs-compatibility message invariant, giving good confidence the fix holds.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| context/prompt_builder.go | Renames BuildMessages to BuildRequest and returns both the compatibility prompt string and native messages in one call; initial requests with no native history reuse the already-rendered compatibility prompt, so render callbacks fire only once instead of twice |
| loop/loop.go | Refactors prompt-build path to call BuildRequest once (instead of BuildPrompt + BuildMessages separately) and collapses duplicate error-handling into a single block; nativeMessages assignment is now unconditional but safe because nil is the zero-value when NativeMessageBuilder is absent |
| loop/loop_test.go | Updates stubPromptBuilder to BuildRequest contract and adds TestLoopNativeRequestRendersInitialPromptOnce covering the render-once fix for initial requests and the separate-base-prompt invariant for tool-follow-up requests |
| context/prompt_builder_test.go | Renames test to TestBuildRequestCombinesPromptAndNativeConversation and adds assertion that the first return value is a valid compatibility prompt containing system instructions and user input |
| agent/agent_test.go | Updates testPromptBuilder to satisfy the new NativeMessageBuilder interface by implementing BuildRequest returning both prompt and messages |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant L as Loop
    participant B as Builder
    participant R as Renderer

    rect rgb(240,248,255)
        Note over L,R: Initial request — no native history
        L->>B: BuildRequest(ctx, l)
        B->>R: BuildPrompt(ctx, l)
        R-->>B: prompt (render callback fires once)
        B-->>L: "prompt, [{user: prompt}]"
        L->>L: "request.Prompt = prompt, request.Messages = [{user: prompt}]"
    end

    rect rgb(255,245,240)
        Note over L,R: Follow-up request — native history present
        L->>B: BuildRequest(ctx, l)
        B->>R: BuildPrompt(ctx, l)
        R-->>B: fullPrompt (callback 1)
        B->>R: "BuildPrompt(ctx, baseConv{})"
        R-->>B: basePrompt (callback 2)
        B-->>L: "fullPrompt, [{user: basePrompt}, assistant, toolResult]"
        L->>L: "request.Prompt = fullPrompt, request.Messages = [base, history...]"
    end
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(context): render native initial requ..."](https://github.com/lace-ai/gai/commit/28329a0b7a7e73a4e8c312f2277380830cdecbd0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49184953)</sub>

<!-- /greptile_comment -->