### PR TITLE
feat: expose streaming completion metadata and usage

### DIFF
--- a/agent/e2e_test.go
+++ b/agent/e2e_test.go
@@ -243,9 +243,13 @@ func TestAgentWorkflowStreamsRetriedAttemptTokens(t *testing.T) {
 		scripts: [][]ai.Token{
 			{
 				{Type: ai.TokenTypeText, Text: "partial"},
+				{Type: ai.TokenTypeCompletion, Completion: &ai.Completion{Usage: ai.Usage{InputTokens: 3, OutputTokens: 2}}},
 				{Err: errors.New("retriable stream error")},
 			},
-			{{Type: ai.TokenTypeText, Text: "final"}},
+			{
+				{Type: ai.TokenTypeText, Text: "final"},
+				{Type: ai.TokenTypeCompletion, Completion: &ai.Completion{Usage: ai.Usage{InputTokens: 5, OutputTokens: 4}}},
+			},
 		},
 	}
 	assistant := agent.New(agent.Definition{
@@ -278,6 +282,12 @@ func TestAgentWorkflowStreamsRetriedAttemptTokens(t *testing.T) {
 	}
 	if got := result.Text; got != "partialfinal" {
 		t.Fatalf("unexpected workflow result text: %q", got)
+	}
+	if result.Usage != (ai.Usage{InputTokens: 5, OutputTokens: 4}) {
+		t.Fatalf("accepted usage = %#v", result.Usage)
+	}
+	if result.BilledUsage != (ai.Usage{InputTokens: 8, OutputTokens: 6}) {
+		t.Fatalf("billed usage = %#v", result.BilledUsage)
 	}
 }
 

--- a/agent/e2e_test.go
+++ b/agent/e2e_test.go
@@ -244,11 +244,13 @@ func TestAgentWorkflowStreamsRetriedAttemptTokens(t *testing.T) {
 			{
 				{Type: ai.TokenTypeText, Text: "partial"},
 				{Type: ai.TokenTypeCompletion, Completion: &ai.Completion{Usage: ai.Usage{InputTokens: 3, OutputTokens: 2}}},
+				{Type: ai.TokenTypeCompletion, Completion: &ai.Completion{Usage: ai.Usage{InputTokens: 4, OutputTokens: 3}}},
 				{Err: errors.New("retriable stream error")},
 			},
 			{
 				{Type: ai.TokenTypeText, Text: "final"},
 				{Type: ai.TokenTypeCompletion, Completion: &ai.Completion{Usage: ai.Usage{InputTokens: 5, OutputTokens: 4}}},
+				{Type: ai.TokenTypeCompletion, Completion: &ai.Completion{Usage: ai.Usage{InputTokens: 6, OutputTokens: 5}}},
 			},
 		},
 	}
@@ -283,10 +285,10 @@ func TestAgentWorkflowStreamsRetriedAttemptTokens(t *testing.T) {
 	if got := result.Text; got != "partialfinal" {
 		t.Fatalf("unexpected workflow result text: %q", got)
 	}
-	if result.Usage != (ai.Usage{InputTokens: 5, OutputTokens: 4}) {
+	if result.Usage != (ai.Usage{InputTokens: 6, OutputTokens: 5}) {
 		t.Fatalf("accepted usage = %#v", result.Usage)
 	}
-	if result.BilledUsage != (ai.Usage{InputTokens: 8, OutputTokens: 6}) {
+	if result.BilledUsage != (ai.Usage{InputTokens: 10, OutputTokens: 8}) {
 		t.Fatalf("billed usage = %#v", result.BilledUsage)
 	}
 }

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -43,7 +43,10 @@ type AgentResult struct {
 	Reasoning  string
 	Messages   []gaictx.Message
 	Iterations []loop.Iteration
-	Errors     []error
+	// Usage totals accepted iteration usage. BilledUsage includes discarded retries.
+	Usage       ai.Usage
+	BilledUsage ai.Usage
+	Errors      []error
 	// Canceled reports that the agent stopped because its context ended.
 	Canceled bool
 	// CancellationErr contains context.Canceled or context.DeadlineExceeded.
@@ -68,8 +71,11 @@ type WorkflowResult struct {
 	Tokens    []ai.Token
 	Text      string
 	Reasoning string
-	Stages    []StageResult
-	Errors    []error
+	// Usage totals accepted iteration usage. BilledUsage includes discarded retries.
+	Usage       ai.Usage
+	BilledUsage ai.Usage
+	Stages      []StageResult
+	Errors      []error
 	// Canceled reports that the workflow stopped because its context ended.
 	Canceled bool
 	// CancellationErr contains context.Canceled or context.DeadlineExceeded.
@@ -292,6 +298,8 @@ func (w *Workflow) capturePrimary(ctx context.Context, upstream Stream, obs *wor
 			Reasoning:       tokenReasoning(captured.Tokens),
 			Messages:        cloneMessages(w.Loop.Messages()),
 			Iterations:      cloneIterations(w.Loop.Iterations),
+			Usage:           iterationUsage(w.Loop.Iterations),
+			BilledUsage:     tokenUsage(captured.Tokens),
 			Errors:          append([]error(nil), captured.Errors...),
 			Canceled:        canceled,
 			CancellationErr: cancellationErr,
@@ -301,6 +309,8 @@ func (w *Workflow) capturePrimary(ctx context.Context, upstream Stream, obs *wor
 		w.result.Tokens = cloneTokens(captured.Tokens)
 		w.result.Text = result.Text
 		w.result.Reasoning = result.Reasoning
+		w.result.Usage = result.Usage
+		w.result.BilledUsage = result.BilledUsage
 		w.result.Errors = append([]error(nil), captured.Errors...)
 		w.result.Canceled = canceled
 		w.result.CancellationErr = cancellationErr
@@ -602,6 +612,24 @@ func cloneMessages(messages []gaictx.Message) []gaictx.Message {
 		}
 	}
 	return cloned
+}
+
+func tokenUsage(tokens []ai.Token) ai.Usage {
+	var usage ai.Usage
+	for _, token := range tokens {
+		if token.Type == ai.TokenTypeCompletion && token.Completion != nil {
+			usage.Add(token.Completion.Usage)
+		}
+	}
+	return usage
+}
+
+func iterationUsage(iterations []loop.Iteration) ai.Usage {
+	var usage ai.Usage
+	for _, iteration := range iterations {
+		usage.Add(iteration.Usage)
+	}
+	return usage
 }
 
 func cloneIterations(iterations []loop.Iteration) []loop.Iteration {

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -299,7 +299,7 @@ func (w *Workflow) capturePrimary(ctx context.Context, upstream Stream, obs *wor
 			Messages:        cloneMessages(w.Loop.Messages()),
 			Iterations:      cloneIterations(w.Loop.Iterations),
 			Usage:           iterationUsage(w.Loop.Iterations),
-			BilledUsage:     tokenUsage(captured.Tokens),
+			BilledUsage:     statusUsage(captured.Statuses),
 			Errors:          append([]error(nil), captured.Errors...),
 			Canceled:        canceled,
 			CancellationErr: cancellationErr,
@@ -614,12 +614,10 @@ func cloneMessages(messages []gaictx.Message) []gaictx.Message {
 	return cloned
 }
 
-func tokenUsage(tokens []ai.Token) ai.Usage {
+func statusUsage(statuses []loop.IterationInformation) ai.Usage {
 	var usage ai.Usage
-	for _, token := range tokens {
-		if token.Type == ai.TokenTypeCompletion && token.Completion != nil {
-			usage.Add(token.Completion.Usage)
-		}
+	for _, status := range statuses {
+		usage.Add(status.Iteration.Usage)
 	}
 	return usage
 }

--- a/ai/openai/model.go
+++ b/ai/openai/model.go
@@ -135,6 +135,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 					}
 					completion.Raw = append(completion.Raw[:0], []byte(chunk.RawJSON())...)
 					snapshot := completion
+					snapshot.Raw = append(json.RawMessage(nil), completion.Raw...)
 					if !ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeCompletion, Completion: &snapshot}) {
 						return
 					}

--- a/ai/openai/model.go
+++ b/ai/openai/model.go
@@ -128,7 +128,8 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 						CachedTokens:    int(chunk.Usage.PromptTokensDetails.CachedTokens),
 					}
 					completion.Raw = append(completion.Raw[:0], []byte(chunk.RawJSON())...)
-					if !ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeCompletion, Completion: &completion}) {
+					snapshot := completion
+					if !ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeCompletion, Completion: &snapshot}) {
 						return
 					}
 				}

--- a/ai/openai/model.go
+++ b/ai/openai/model.go
@@ -116,9 +116,15 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			}
 		}()
 		calls := map[int64]*streamToolCall{}
-		var completion ai.Completion
+		completion := ai.Completion{Provider: "openai"}
 		for stream.Next() {
 			chunk := stream.Current()
+			if chunk.ID != "" {
+				completion.RequestID = chunk.ID
+			}
+			if chunk.Model != "" {
+				completion.Model = chunk.Model
+			}
 			if len(chunk.Choices) == 0 {
 				if chunk.JSON.Usage.Valid() {
 					completion.Usage = ai.Usage{
@@ -135,9 +141,6 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 				}
 				continue
 			}
-			completion.RequestID = chunk.ID
-			completion.Provider = "openai"
-			completion.Model = chunk.Model
 			choice := chunk.Choices[0]
 			if choice.FinishReason != "" {
 				completion.FinishReason = string(choice.FinishReason)

--- a/ai/openai/model.go
+++ b/ai/openai/model.go
@@ -116,12 +116,31 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			}
 		}()
 		calls := map[int64]*streamToolCall{}
+		var completion ai.Completion
 		for stream.Next() {
 			chunk := stream.Current()
 			if len(chunk.Choices) == 0 {
+				if chunk.JSON.Usage.Valid() {
+					completion.Usage = ai.Usage{
+						InputTokens:     int(chunk.Usage.PromptTokens),
+						OutputTokens:    int(chunk.Usage.CompletionTokens),
+						ReasoningTokens: int(chunk.Usage.CompletionTokensDetails.ReasoningTokens),
+						CachedTokens:    int(chunk.Usage.PromptTokensDetails.CachedTokens),
+					}
+					completion.Raw = append(completion.Raw[:0], []byte(chunk.RawJSON())...)
+					if !ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeCompletion, Completion: &completion}) {
+						return
+					}
+				}
 				continue
 			}
+			completion.RequestID = chunk.ID
+			completion.Provider = "openai"
+			completion.Model = chunk.Model
 			choice := chunk.Choices[0]
+			if choice.FinishReason != "" {
+				completion.FinishReason = string(choice.FinishReason)
+			}
 			if text := choice.Delta.Content; text != "" {
 				if !ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeText, Data: []byte(text), Text: text}) {
 					return
@@ -252,7 +271,7 @@ func openAIDescriptor(model string) ai.ModelDescriptor {
 		Model: model, NativeMessages: ai.FeatureSupportSupported, NativeTools: ai.FeatureSupportSupported,
 		ToolChoiceModes: []ai.ToolChoiceMode{ai.ToolChoiceAuto, ai.ToolChoiceNone, ai.ToolChoiceRequired},
 		Multimodal:      ai.FeatureSupportUnsupported,
-		Usage:           ai.FeatureSupportSupported, FinishReason: ai.FeatureSupportUnsupported, StreamingUsage: ai.FeatureSupportUnsupported,
+		Usage:           ai.FeatureSupportSupported, FinishReason: ai.FeatureSupportSupported, StreamingUsage: ai.FeatureSupportSupported,
 		ToolCalling: ai.FeatureSupportSupported,
 		JSONOutput:  ai.FeatureSupportSupported, JSONSchemaOutput: ai.FeatureSupportSupported,
 		Tokenizer: ai.TokenizerDescriptor{Available: ai.FeatureSupportUnsupported},

--- a/ai/openai/model_test.go
+++ b/ai/openai/model_test.go
@@ -534,6 +534,33 @@ func TestModelGenerateStreamPreservesUsageOnlyTerminalChunk(t *testing.T) {
 	}
 }
 
+func TestModelGenerateStreamPreservesMetadataFromSoleUsageOnlyChunk(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl_sole\",\"model\":\"gpt-4.1-mini\",\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":7}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+
+	p := New("test-key", nil)
+	p.baseURL = ts.URL
+	m, err := p.Model(GPT41Mini)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tokens []ai.Token
+	for token := range m.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+		tokens = append(tokens, token)
+	}
+	if len(tokens) != 1 || tokens[0].Type != ai.TokenTypeCompletion {
+		t.Fatalf("tokens = %#v", tokens)
+	}
+	completion := tokens[0].Completion
+	if completion == nil || completion.RequestID != "chatcmpl_sole" || completion.Provider != "openai" || completion.Model != GPT41Mini {
+		t.Fatalf("completion = %#v", completion)
+	}
+}
+
 func TestModelGenerateStreamSnapshotsUsageOnlyCompletion(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/ai/openai/model_test.go
+++ b/ai/openai/model_test.go
@@ -534,6 +534,34 @@ func TestModelGenerateStreamPreservesUsageOnlyTerminalChunk(t *testing.T) {
 	}
 }
 
+func TestModelGenerateStreamSnapshotsUsageOnlyCompletion(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":7}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl_later\",\"model\":\"gpt-4.1-mini\",\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":\"stop\"}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+
+	p := New("test-key", nil)
+	p.baseURL = ts.URL
+	m, err := p.Model(GPT41Mini)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tokens []ai.Token
+	for token := range m.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+		tokens = append(tokens, token)
+	}
+	if len(tokens) != 2 || tokens[0].Type != ai.TokenTypeCompletion {
+		t.Fatalf("tokens = %#v", tokens)
+	}
+	completion := tokens[0].Completion
+	if completion == nil || completion.Usage.InputTokens != 11 || completion.Usage.OutputTokens != 7 || completion.RequestID != "" || completion.Model != "" || completion.FinishReason != "" {
+		t.Fatalf("completion must be a snapshot of the usage-only chunk, got %#v", completion)
+	}
+}
+
 func TestModelGenerateStreamEmitsToolCallsByIndex(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/ai/openai/model_test.go
+++ b/ai/openai/model_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/lace-ai/gai/ai"
@@ -586,6 +587,35 @@ func TestModelGenerateStreamSnapshotsUsageOnlyCompletion(t *testing.T) {
 	completion := tokens[0].Completion
 	if completion == nil || completion.Usage.InputTokens != 11 || completion.Usage.OutputTokens != 7 || completion.RequestID != "" || completion.Model != "" || completion.FinishReason != "" {
 		t.Fatalf("completion must be a snapshot of the usage-only chunk, got %#v", completion)
+	}
+}
+
+func TestModelGenerateStreamSnapshotsRawForEachUsageOnlyCompletion(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":7}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"choices\":[],\"usage\":{\"prompt_tokens\":13,\"completion_tokens\":9}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+
+	p := New("test-key", nil)
+	p.baseURL = ts.URL
+	m, err := p.Model(GPT41Mini)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var completions []*ai.Completion
+	for token := range m.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+		if token.Type == ai.TokenTypeCompletion {
+			completions = append(completions, token.Completion)
+		}
+	}
+	if len(completions) != 2 {
+		t.Fatalf("completion count = %d, want 2", len(completions))
+	}
+	if !strings.Contains(string(completions[0].Raw), `"prompt_tokens":11`) || !strings.Contains(string(completions[1].Raw), `"prompt_tokens":13`) {
+		t.Fatalf("completion raw values must remain distinct: first=%s second=%s", completions[0].Raw, completions[1].Raw)
 	}
 }
 

--- a/ai/openai/model_test.go
+++ b/ai/openai/model_test.go
@@ -506,6 +506,34 @@ func TestModelGenerateStreamMapsTextAndToolCalls(t *testing.T) {
 	}
 }
 
+func TestModelGenerateStreamPreservesUsageOnlyTerminalChunk(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl_1\",\"model\":\"gpt-4.1-mini\",\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":\"stop\"}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl_1\",\"model\":\"gpt-4.1-mini\",\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":7,\"completion_tokens_details\":{\"reasoning_tokens\":3},\"prompt_tokens_details\":{\"cached_tokens\":2}}}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+
+	p := New("test-key", nil)
+	p.baseURL = ts.URL
+	m, err := p.Model(GPT41Mini)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tokens []ai.Token
+	for token := range m.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+		tokens = append(tokens, token)
+	}
+	if len(tokens) != 2 || tokens[1].Type != ai.TokenTypeCompletion {
+		t.Fatalf("tokens = %#v", tokens)
+	}
+	completion := tokens[1].Completion
+	if completion == nil || completion.Usage.InputTokens != 11 || completion.Usage.OutputTokens != 7 || completion.Usage.ReasoningTokens != 3 || completion.Usage.CachedTokens != 2 || completion.FinishReason != "stop" || completion.RequestID != "chatcmpl_1" || completion.Provider != "openai" || completion.Model != GPT41Mini {
+		t.Fatalf("completion = %#v", completion)
+	}
+}
+
 func TestModelGenerateStreamEmitsToolCallsByIndex(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
@@ -715,7 +743,7 @@ func TestModelDescriptorDoesNotAdvertiseUnsupportedTokenizer(t *testing.T) {
 	if d.Tokenizer.Available != ai.FeatureSupportUnsupported || d.Tokenizer.Fidelity != ai.TokenizerFidelityUnknown {
 		t.Fatalf("tokenizer descriptor = %#v, want unsupported/unknown", d.Tokenizer)
 	}
-	if d.NativeMessages != ai.FeatureSupportSupported || d.NativeTools != ai.FeatureSupportSupported || d.Multimodal != ai.FeatureSupportUnsupported || d.Usage != ai.FeatureSupportSupported || d.FinishReason != ai.FeatureSupportUnsupported || d.StreamingUsage != ai.FeatureSupportUnsupported {
+	if d.NativeMessages != ai.FeatureSupportSupported || d.NativeTools != ai.FeatureSupportSupported || d.Multimodal != ai.FeatureSupportUnsupported || d.Usage != ai.FeatureSupportSupported || d.FinishReason != ai.FeatureSupportSupported || d.StreamingUsage != ai.FeatureSupportSupported {
 		t.Fatalf("capability descriptor = %#v", d)
 	}
 }

--- a/ai/response.go
+++ b/ai/response.go
@@ -138,7 +138,7 @@ func (r *AIResponse) AppendToken(t Token) {
 		}
 	case TokenTypeCompletion:
 		if t.Completion != nil {
-			r.InputTokens += t.Completion.Usage.InputTokens
+			r.InputTokens = t.Completion.Usage.InputTokens
 			r.OutputTokens = t.Completion.Usage.OutputTokens
 			r.ReasoningTokens = t.Completion.Usage.ReasoningTokens
 			r.FinishReason = t.Completion.FinishReason

--- a/ai/response.go
+++ b/ai/response.go
@@ -25,6 +25,32 @@ type AIResponse struct {
 	ReasoningTokens int
 }
 
+// Usage is normalized provider token accounting for one completed request.
+type Usage struct {
+	InputTokens     int
+	OutputTokens    int
+	ReasoningTokens int
+	CachedTokens    int
+}
+
+// Add accumulates another provider usage record.
+func (u *Usage) Add(other Usage) {
+	u.InputTokens += other.InputTokens
+	u.OutputTokens += other.OutputTokens
+	u.ReasoningTokens += other.ReasoningTokens
+	u.CachedTokens += other.CachedTokens
+}
+
+// Completion is terminal metadata emitted by a streaming provider request.
+type Completion struct {
+	Usage        Usage
+	FinishReason string
+	RequestID    string
+	Provider     string
+	Model        string
+	Raw          json.RawMessage
+}
+
 // TokenType identifies the semantic kind of a streamed token.
 type TokenType string
 
@@ -37,6 +63,8 @@ var (
 	TokenTypeToolCall TokenType = "tool_call"
 	// TokenTypeErr identifies an error emitted through the token stream.
 	TokenTypeErr TokenType = "error"
+	// TokenTypeCompletion identifies terminal provider metadata for a completed stream.
+	TokenTypeCompletion TokenType = "completion"
 )
 
 // Token is one event emitted by Model.GenerateStream.
@@ -58,6 +86,8 @@ type Token struct {
 	Text string
 	// Err contains the stream error for TokenTypeErr.
 	Err error
+	// Completion contains terminal provider metadata for TokenTypeCompletion.
+	Completion *Completion
 }
 
 // String returns the token's raw Data as a string.
@@ -106,6 +136,15 @@ func (r *AIResponse) AppendToken(t Token) {
 			tc.ThoughtSignature = append([]byte(nil), t.ToolCall.ThoughtSignature...)
 			r.ToolCalls = append(r.ToolCalls, tc)
 		}
+	case TokenTypeCompletion:
+		if t.Completion != nil {
+			r.InputTokens += t.Completion.Usage.InputTokens
+			r.OutputTokens = t.Completion.Usage.OutputTokens
+			r.ReasoningTokens = t.Completion.Usage.ReasoningTokens
+			r.FinishReason = t.Completion.FinishReason
+			r.Raw = append(r.Raw[:0], t.Completion.Raw...)
+		}
+		return
 	}
 
 	r.OutputTokens += t.TokenUsage

--- a/ai/response_test.go
+++ b/ai/response_test.go
@@ -50,6 +50,21 @@ func TestAIResponseAppendTokenSeparatesThoughtsAndToolCalls(t *testing.T) {
 	}
 }
 
+func TestAIResponseAppendTokenCompletionUsesLatestUsage(t *testing.T) {
+	var response ai.AIResponse
+
+	response.AppendToken(ai.Token{Type: ai.TokenTypeCompletion, Completion: &ai.Completion{
+		Usage: ai.Usage{InputTokens: 10, OutputTokens: 4, ReasoningTokens: 2},
+	}})
+	response.AppendToken(ai.Token{Type: ai.TokenTypeCompletion, Completion: &ai.Completion{
+		Usage: ai.Usage{InputTokens: 12, OutputTokens: 6, ReasoningTokens: 3},
+	}})
+
+	if response.InputTokens != 12 || response.OutputTokens != 6 || response.ReasoningTokens != 3 {
+		t.Fatalf("completion usage should use the latest provider values, got %#v", response)
+	}
+}
+
 type expectedWrapToken struct {
 	typ          ai.TokenType
 	data         string

--- a/loop/iteration.go
+++ b/loop/iteration.go
@@ -154,7 +154,7 @@ func (i *Iteration) AppendToken(t ai.Token) {
 		if t.Completion == nil {
 			return
 		}
-		i.Usage.Add(t.Completion.Usage)
+		i.Usage = t.Completion.Usage
 		if last != nil && last.Type == IterationTypeResponse {
 			last.Response.AppendToken(t)
 		} else {

--- a/loop/iteration.go
+++ b/loop/iteration.go
@@ -53,6 +53,8 @@ type Iteration struct {
 	Parts []IterationPart
 	// UserMessage is the structured user input retained by the first iteration.
 	UserMessage *gaictx.Message
+	// Usage is the provider-reported usage for the accepted generation attempt.
+	Usage ai.Usage
 }
 
 // IterationPart contains one response, tool call, or tool result segment.
@@ -148,6 +150,18 @@ func (i *Iteration) AppendToken(t ai.Token) {
 	}
 
 	switch t.Type {
+	case ai.TokenTypeCompletion:
+		if t.Completion == nil {
+			return
+		}
+		i.Usage.Add(t.Completion.Usage)
+		if last != nil && last.Type == IterationTypeResponse {
+			last.Response.AppendToken(t)
+		} else {
+			response := &ai.AIResponse{}
+			response.AppendToken(t)
+			i.Parts = append(i.Parts, IterationPart{Type: IterationTypeResponse, Response: response})
+		}
 	case ai.TokenTypeText:
 		if last != nil && last.Type == IterationTypeResponse {
 			last.Response.AppendToken(t)

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -1229,6 +1229,22 @@ func TestIterationCountsLeadingThoughtTokens(t *testing.T) {
 	}
 }
 
+func TestIterationCompletionUsageUsesLatestProviderValues(t *testing.T) {
+	t.Parallel()
+
+	var iteration loop.Iteration
+	iteration.AppendToken(ai.Token{Type: ai.TokenTypeCompletion, Completion: &ai.Completion{
+		Usage: ai.Usage{InputTokens: 10, OutputTokens: 4, ReasoningTokens: 2},
+	}})
+	iteration.AppendToken(ai.Token{Type: ai.TokenTypeCompletion, Completion: &ai.Completion{
+		Usage: ai.Usage{InputTokens: 12, OutputTokens: 6, ReasoningTokens: 3},
+	}})
+
+	if iteration.Usage != (ai.Usage{InputTokens: 12, OutputTokens: 6, ReasoningTokens: 3}) {
+		t.Fatalf("completion usage should use the latest provider values, got %#v", iteration.Usage)
+	}
+}
+
 func TestLoopCreatesToolSpans(t *testing.T) {
 	previousProvider := otel.GetTracerProvider()
 	recorder := tracetest.NewSpanRecorder()


### PR DESCRIPTION
Closes #79

Adds a terminal stream completion event with normalized usage and OpenAI chat-completions usage-only chunk handling. Loop/workflow results expose accepted usage separately from billed usage across retries.

Tests: `go test ./...`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added usage reporting for streamed AI responses, including token counts, completion details, finish reasons, and provider metadata.
  * Workflow results now distinguish usage from the accepted attempt and total billed usage across retries.

* **Bug Fixes**
  * Improved usage tracking when providers send usage-only streaming updates.
  * Ensured retry workflows report accurate accepted and billed usage totals.
  * Preserved complete streaming metadata and response snapshots across completion updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `TokenTypeCompletion` stream event carrying normalized `Usage`, `FinishReason`, `RequestID`, `Provider`, and `Model` metadata; wires it through the OpenAI streaming path; and surfaces accepted vs. billed usage on `AgentResult` and `WorkflowResult`.

- **`ai/` layer**: New `Usage` and `Completion` types; `AppendToken` handles `TokenTypeCompletion` with last-wins semantics for provider-authoritative values; OpenAI model sends a defensive value-copy snapshot on usage-only chunks.
- **`loop/iteration.go`**: `Iteration.Usage` tracks accepted-attempt usage via last-wins assignment on completion tokens.
- **`agent/workflow.go`**: `capturePrimary` (the deprecated `Run` path) now correctly computes `Usage` via `iterationUsage` and `BilledUsage` via `statusUsage`; however `captureEvents` (the preferred `RunEvents` path) does not populate either field, leaving them zero for all callers on that path.

<h3>Confidence Score: 4/5</h3>

Safe to merge only if callers exclusively use the deprecated Run path; RunEvents callers will silently receive zero usage counts.

The `captureEvents` function — powering the documented preferred API `RunEvents()` — never populates the `Usage` or `BilledUsage` fields that this PR introduces. Any consumer reading usage after calling `RunEvents()` gets zeros. The fix is straightforward but until it lands the feature is incomplete on the primary code path.

**Files Needing Attention:** agent/workflow.go — specifically the captureEvents function which is untouched by this PR despite being the preferred consumer path.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| agent/workflow.go | Adds Usage/BilledUsage fields and populates them in capturePrimary, but captureEvents (the preferred RunEvents path) never sets either field, making usage always zero on that path. |
| ai/response.go | Adds Usage, Completion structs and TokenTypeCompletion; AppendToken correctly uses last-wins assignment for all three usage fields on completion tokens. |
| ai/openai/model.go | Accumulates request metadata across chunks into a shared completion struct and sends a defensive value-copy snapshot on usage-only chunks; snapshot.Raw is independently copied, preventing aliasing. |
| loop/iteration.go | Adds Usage field to Iteration and correctly uses last-wins assignment in AppendToken for TokenTypeCompletion. |
| ai/openai/model_test.go | Good coverage for snapshot isolation, sole-chunk metadata, and multi-usage-chunk raw distinctness; updates descriptor assertion for FinishReason/StreamingUsage now being supported. |
| agent/e2e_test.go | Extends retry test to assert accepted Usage and BilledUsage; expected values are arithmetically correct. |
| ai/response_test.go | Adds test confirming last-wins semantics for multiple completion tokens on a single AIResponse. |
| loop/loop_test.go | Adds test for Iteration.Usage last-wins behavior on multiple completion tokens. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Provider as OpenAI Provider
    participant Stream as Token Stream
    participant Iteration as loop.Iteration
    participant Workflow as agent.Workflow

    Provider->>Stream: TokenTypeText
    Stream->>Iteration: "AppendToken → Part{Response}"

    Provider->>Stream: TokenTypeCompletion (usage-only chunk)
    Note over Provider,Stream: snapshot := completion copy, Raw independently copied
    Stream->>Iteration: "AppendToken → i.Usage = completion.Usage (last-wins)"
    Stream->>Iteration: last.Response.AppendToken → InputTokens/OutputTokens/FinishReason

    Iteration-->>Workflow: capturePrimary path (Run/deprecated)
    Note over Workflow: Usage = iterationUsage(Loop.Iterations)
    Note over Workflow: BilledUsage = statusUsage(captured.Statuses)
    Workflow-->>Workflow: w.result.Usage populated correctly

    Iteration-->>Workflow: captureEvents path (RunEvents/preferred)
    Note over Workflow: Usage not set → 0, BilledUsage not set → 0
    Workflow-->>Workflow: w.result.Usage always zero
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `agent/workflow.go`, line 342-395 ([link](https://github.com/lace-ai/gai/blob/b08a4884dd3d50bc9f45d4e6f35a507727426d41/agent/workflow.go#L342-L395)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`captureEvents` silently returns zero `Usage` and `BilledUsage`**

   `RunEvents` is documented as the "preferred API for consumers that need causal ordering," yet the `captureEvents` goroutine builds its `AgentResult` and `WorkflowResult` without populating `Usage` or `BilledUsage`. Any caller that runs the workflow via `RunEvents()` and then inspects `w.Result()` will see zero token counts regardless of what completion tokens the model emitted.

   `capturePrimary` (used by the deprecated `Run` path) correctly sets both fields — `iterationUsage(w.Loop.Iterations)` for `Usage` and `statusUsage(captured.Statuses)` for `BilledUsage` — but `captureEvents` omits both. `w.Loop.Iterations` is accessible after the event loop drains, so `Usage` can be computed the same way. `BilledUsage` requires accumulating iteration data from `EventRetry`, `EventIterationDone`, `EventError`, and `EventCanceled` events as they are processed (similar to how `loopEventsToStream` builds statuses for the `Run` path).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: agent/workflow.go
   Line: 342-395

   Comment:
   **`captureEvents` silently returns zero `Usage` and `BilledUsage`**

   `RunEvents` is documented as the "preferred API for consumers that need causal ordering," yet the `captureEvents` goroutine builds its `AgentResult` and `WorkflowResult` without populating `Usage` or `BilledUsage`. Any caller that runs the workflow via `RunEvents()` and then inspects `w.Result()` will see zero token counts regardless of what completion tokens the model emitted.

   `capturePrimary` (used by the deprecated `Run` path) correctly sets both fields — `iterationUsage(w.Loop.Iterations)` for `Usage` and `statusUsage(captured.Statuses)` for `BilledUsage` — but `captureEvents` omits both. `w.Loop.Iterations` is accessible after the event loop drains, so `Usage` can be computed the same way. `BilledUsage` requires accumulating iteration data from `EventRetry`, `EventIterationDone`, `EventError`, and `EventCanceled` events as they are processed (similar to how `loopEventsToStream` builds statuses for the `Run` path).

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

2. `agent/workflow.go`, line 342-395 ([link](https://github.com/lace-ai/gai/blob/b08a4884dd3d50bc9f45d4e6f35a507727426d41/agent/workflow.go#L342-L395)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`captureEvents` silently produces zero `Usage` and `BilledUsage`**

   `RunEvents()` is documented as the "preferred API for consumers that need causal ordering", yet `captureEvents` never sets `Usage` or `BilledUsage` on either the `primary` `AgentResult` or `w.result`. Any caller that drives the workflow through `RunEvents()` and then inspects `w.Result().Usage` will see `{0,0,0,0}` regardless of what the model emitted — directly defeating the core feature this PR adds.

   `capturePrimary` (the deprecated `Run` path) correctly computes both: `iterationUsage(w.Loop.Iterations)` for `Usage` (available after the event loop drains, same as the `Messages` and `Iterations` calls already present) and a per-event accumulation for `BilledUsage`. The `captureEvents` goroutine would need to accumulate iteration usage from `loop.EventRetry`, `loop.EventIterationDone`, and `loop.EventError` events (each carries a non-nil `Iteration` when an attempt completed) to replicate the `statusUsage` logic.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: agent/workflow.go
   Line: 342-395

   Comment:
   **`captureEvents` silently produces zero `Usage` and `BilledUsage`**

   `RunEvents()` is documented as the "preferred API for consumers that need causal ordering", yet `captureEvents` never sets `Usage` or `BilledUsage` on either the `primary` `AgentResult` or `w.result`. Any caller that drives the workflow through `RunEvents()` and then inspects `w.Result().Usage` will see `{0,0,0,0}` regardless of what the model emitted — directly defeating the core feature this PR adds.

   `capturePrimary` (the deprecated `Run` path) correctly computes both: `iterationUsage(w.Loop.Iterations)` for `Usage` (available after the event loop drains, same as the `Messages` and `Iterations` calls already present) and a per-event accumulation for `BilledUsage`. The `captureEvents` goroutine would need to accumulate iteration usage from `loop.EventRetry`, `loop.EventIterationDone`, and `loop.EventError` events (each carries a non-nil `Iteration` when an attempt completed) to replicate the `statusUsage` logic.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
agent/workflow.go:342-395
**`captureEvents` silently produces zero `Usage` and `BilledUsage`**

`RunEvents()` is documented as the "preferred API for consumers that need causal ordering", yet `captureEvents` never sets `Usage` or `BilledUsage` on either the `primary` `AgentResult` or `w.result`. Any caller that drives the workflow through `RunEvents()` and then inspects `w.Result().Usage` will see `{0,0,0,0}` regardless of what the model emitted — directly defeating the core feature this PR adds.

`capturePrimary` (the deprecated `Run` path) correctly computes both: `iterationUsage(w.Loop.Iterations)` for `Usage` (available after the event loop drains, same as the `Messages` and `Iterations` calls already present) and a per-event accumulation for `BilledUsage`. The `captureEvents` goroutine would need to accumulate iteration usage from `loop.EventRetry`, `loop.EventIterationDone`, and `loop.EventError` events (each carries a non-nil `Iteration` when an attempt completed) to replicate the `statusUsage` logic.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["fix: use latest completion usage per att..."](https://github.com/lace-ai/gai/commit/b08a4884dd3d50bc9f45d4e6f35a507727426d41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49219526)</sub>

<!-- /greptile_comment -->