### PR TITLE
ref(obs) add langfuse traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,10 @@ oversized entries are omitted instead of truncated. Trace context uses an intern
 context value, not OpenTelemetry baggage, so GAI does not add user or session
 identifiers to outbound request headers.
 
+Environment values are trimmed and normalized to lowercase. They may contain
+letters, digits, hyphens, and underscores; values beginning with `langfuse` are
+reserved by Langfuse and omitted.
+
 The core library records provider-neutral `gai.trace.*` attributes. The
 Langfuse tracer provider maps them to Langfuse v4 trace attributes on every
 span. Applications assembling their own Langfuse tracer provider can wrap a

--- a/README.md
+++ b/README.md
@@ -364,6 +364,43 @@ otel.SetTracerProvider(provider)
 
 The caller owns provider shutdown so the final batch can be flushed and any export error can be observed.
 
+Trace-wide filtering dimensions are opt-in and separate from `RunInput.Meta`:
+
+```go
+traceContext := &gai.TraceContext{
+  Name:        "lace-chat",
+  UserID:      userID,
+  SessionID:   conversationID,
+  Tags:        []string{"mobile"},
+  Release:     version,
+  Environment: "production",
+  Metadata: map[string]string{
+    "feature": "chat",
+  },
+}
+
+workflow, err := assistant.NewRun(ctx, agent.RunInput{
+  TraceContext: traceContext,
+  Prompt:       input,
+  Meta:         applicationData, // values are still never exported implicitly
+})
+```
+
+`RunInput.TraceContext == nil` inherits trace dimensions already installed with
+`gai.WithTraceContext`; a non-nil value replaces them as a complete set. GAI
+copies and validates the value before asynchronous work starts. Scalar values
+are limited to 200 bytes, tags to 32 values of 200 bytes, and selected metadata
+to 32 entries with 64-byte alphanumeric keys and 200-byte values. Invalid or
+oversized entries are omitted instead of truncated. Trace context uses an internal Go
+context value, not OpenTelemetry baggage, so GAI does not add user or session
+identifiers to outbound request headers.
+
+The core library records provider-neutral `gai.trace.*` attributes. The
+Langfuse tracer provider maps them to Langfuse v4 trace attributes on every
+span. Applications assembling their own Langfuse tracer provider can wrap a
+span processor with `langfuse.NewTraceContextSpanProcessor` to use the same
+mapping.
+
 ## Package map
 
 ```text

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -13,6 +13,9 @@ import (
 // RunInput contains the application input for one agent run.
 type RunInput struct {
 	ID string
+	// TraceContext explicitly selects approved trace-wide dimensions. Nil
+	// inherits a trace context already present in ctx; non-nil replaces it.
+	TraceContext *gai.TraceContext
 	// Prompt separates genuine user content from structured machine context.
 	Prompt gaictx.PromptInput
 	// MaxTokens overrides Definition.Limits.MaxTokens when it is positive.
@@ -84,6 +87,7 @@ func New(def Definition) *Agent {
 // Prompt construction happens before NewRun returns. Model execution and
 // middleware processing begin when Workflow.Run is called.
 func (a *Agent) NewRun(ctx context.Context, input RunInput) (*Workflow, error) {
+	ctx, input = resolveRunTraceContext(ctx, input)
 	ctx, obs := newRunCreationObserver(ctx, a, input)
 	if a != nil {
 		if err := validateMiddleware(a.def.Middleware); err != nil {
@@ -102,6 +106,16 @@ func (a *Agent) NewRun(ctx context.Context, input RunInput) (*Workflow, error) {
 	obs.Created(ctx)
 	obs.Finish(nil)
 	return workflow, nil
+}
+
+func resolveRunTraceContext(ctx context.Context, input RunInput) (context.Context, RunInput) {
+	if input.TraceContext != nil {
+		ctx = gai.WithTraceContext(ctx, *input.TraceContext)
+	}
+	if traceContext, ok := gai.TraceContextFromContext(ctx); ok {
+		input.TraceContext = &traceContext
+	}
+	return ctx, input
 }
 
 func (a *Agent) name() string {

--- a/agent/obs_test.go
+++ b/agent/obs_test.go
@@ -3,6 +3,7 @@ package agent_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/lace-ai/gai/agent"
 	"github.com/lace-ai/gai/ai"
 	gaictx "github.com/lace-ai/gai/context"
+	"github.com/lace-ai/gai/loop"
 	"github.com/lace-ai/gai/testutil/mocks"
 	"go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
@@ -225,6 +227,227 @@ func TestAgentObservabilityReportsCreationAndMiddlewareFailures(t *testing.T) {
 	if !ok || !errors.Is(event.Err, mapErr) {
 		t.Fatalf("missing middleware failure event: %+v", event)
 	}
+}
+
+type traceTestModel struct {
+	mu      sync.Mutex
+	scripts [][]ai.Token
+	call    int
+}
+
+func (m *traceTestModel) Name() string { return "trace-test-model" }
+
+func (m *traceTestModel) Generate(context.Context, ai.AIRequest) (*ai.AIResponse, error) {
+	return &ai.AIResponse{}, nil
+}
+
+func (m *traceTestModel) GenerateStream(ctx context.Context, _ ai.AIRequest) <-chan ai.Token {
+	ctx, span := gai.StartOperationSpan(ctx, "gai-test", "test.model", "test.operation", "generate")
+	m.mu.Lock()
+	call := m.call
+	m.call++
+	var script []ai.Token
+	if call < len(m.scripts) {
+		script = append([]ai.Token(nil), m.scripts[call]...)
+	}
+	m.mu.Unlock()
+	out := make(chan ai.Token, len(script))
+	go func() {
+		defer close(out)
+		defer span.End()
+		for _, token := range script {
+			select {
+			case out <- token:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return out
+}
+
+func (*traceTestModel) Close() error            { return nil }
+func (*traceTestModel) Tokenizer() ai.Tokenizer { return &mocks.MockTokenizer{} }
+
+type traceTestTool struct{ loop.Tool }
+
+func (t traceTestTool) Function(ctx context.Context, call *ai.ToolCall) *loop.ToolResponse {
+	ctx, span := gai.StartOperationSpan(ctx, "gai-test", "test.tool", "test.operation", "execute")
+	defer span.End()
+	return t.Tool.Function(ctx, call)
+}
+
+func TestTraceContextPropagatesAcrossRetriesToolsAndNestedMiddleware(t *testing.T) {
+	previousProvider := otel.GetTracerProvider()
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		otel.SetTracerProvider(previousProvider)
+	})
+
+	primaryModel := &traceTestModel{scripts: [][]ai.Token{
+		{{Type: ai.TokenTypeErr, Err: errors.New("retry")}},
+		{{Type: ai.TokenTypeToolCall, ToolCall: &ai.ToolCall{ID: "call-1", Type: "function", Name: "echo", Args: []byte(`{"text":"hello"}`)}}},
+		{{Type: ai.TokenTypeText, Text: "primary"}},
+	}}
+	postModel := &traceTestModel{scripts: [][]ai.Token{{{Type: ai.TokenTypeText, Text: "post"}}}}
+	post := agent.New(agent.Definition{
+		Name:  "post",
+		Model: postModel,
+		Prompt: func(context.Context, agent.RunInput) (gaictx.PromptBuilder, error) {
+			return &testPromptBuilder{}, nil
+		},
+	})
+	primary := agent.New(agent.Definition{
+		Name:  "primary",
+		Model: primaryModel,
+		Tools: []loop.Tool{traceTestTool{Tool: loop.NewEchoTool()}},
+		Prompt: func(context.Context, agent.RunInput) (gaictx.PromptBuilder, error) {
+			return &testPromptBuilder{}, nil
+		},
+		Middleware: []agent.Middleware{agent.NewAgentMiddleware(post, agent.AgentMiddlewareConfig{Output: agent.PreserveOutput})},
+	})
+
+	traceContext := &gai.TraceContext{
+		Name:        "lace-chat",
+		UserID:      "user-1",
+		SessionID:   "session-1",
+		Tags:        []string{"mobile"},
+		Release:     "2026.08",
+		Environment: "staging",
+		Metadata:    map[string]string{"feature": "chat"},
+	}
+	workflow, err := primary.NewRun(t.Context(), agent.RunInput{
+		ID:           "run-1",
+		TraceContext: traceContext,
+		Prompt:       gaictx.PromptInput{User: gaictx.NewTextContent("question")},
+		Meta:         map[string]any{"private": "meta-secret"},
+	})
+	if err != nil {
+		t.Fatalf("NewRun failed: %v", err)
+	}
+	traceContext.UserID = "mutated-user"
+	traceContext.Tags[0] = "mutated-tag"
+	traceContext.Metadata["feature"] = "mutated-feature"
+	if consumed := consumeWorkflow(t, workflow); len(consumed.errs) != 0 {
+		t.Fatalf("workflow errors: %v", consumed.errs)
+	}
+
+	required := map[string]bool{
+		"agent.run":            false,
+		"agent.workflow.run":   false,
+		"agent.middleware.run": false,
+		"loop.run":             false,
+		"loop.iteration":       false,
+		"loop.tool":            false,
+		"test.model.generate":  false,
+		"test.tool.execute":    false,
+	}
+	for _, span := range recorder.Ended() {
+		attributes := spanAttributeMap(span)
+		if _, tracked := required[span.Name()]; tracked {
+			required[span.Name()] = true
+			if attributes["gai.trace.name"] != "lace-chat" || attributes["gai.trace.user_id"] != "user-1" || attributes["gai.trace.session_id"] != "session-1" || attributes["gai.trace.release"] != "2026.08" || attributes["gai.trace.environment"] != "staging" || attributes["gai.trace.metadata.feature"] != "chat" {
+				t.Errorf("span %q missing trace context: %#v", span.Name(), attributes)
+			}
+			tags, ok := attributes["gai.trace.tags"].([]string)
+			if !ok || len(tags) != 1 || tags[0] != "mobile" {
+				t.Errorf("span %q tags = %#v", span.Name(), attributes["gai.trace.tags"])
+			}
+		}
+		if strings.Contains(fmt.Sprint(attributes), "meta-secret") || strings.Contains(fmt.Sprint(attributes), "mutated-") {
+			t.Errorf("span %q leaked unapproved or mutated values: %#v", span.Name(), attributes)
+		}
+	}
+	for name, seen := range required {
+		if !seen {
+			t.Errorf("missing traced operation %q", name)
+		}
+	}
+}
+
+func TestRunInputTraceContextInheritsOrReplacesAtomically(t *testing.T) {
+	a := agent.New(agent.Definition{
+		Name:  "trace-context",
+		Model: &mocks.MockModel{},
+		Prompt: func(context.Context, agent.RunInput) (gaictx.PromptBuilder, error) {
+			return &testPromptBuilder{}, nil
+		},
+	})
+	inheritedCtx := gai.WithTraceContext(t.Context(), gai.TraceContext{UserID: "inherited", SessionID: "keep-only-on-inherit"})
+	inherited, err := a.NewRun(inheritedCtx, textRunInput("inherit"))
+	if err != nil {
+		t.Fatalf("NewRun inherited: %v", err)
+	}
+	if got := inherited.Result().Input.TraceContext; got == nil || got.UserID != "inherited" || got.SessionID != "keep-only-on-inherit" {
+		t.Fatalf("inherited trace context = %#v", got)
+	}
+
+	replacementInput := textRunInput("replace")
+	replacementInput.TraceContext = &gai.TraceContext{UserID: "replacement"}
+	replaced, err := a.NewRun(inheritedCtx, replacementInput)
+	if err != nil {
+		t.Fatalf("NewRun replaced: %v", err)
+	}
+	if got := replaced.Result().Input.TraceContext; got == nil || got.UserID != "replacement" || got.SessionID != "" {
+		t.Fatalf("replacement retained inherited fields: %#v", got)
+	}
+}
+
+func TestTraceContextSurvivesCanceledRunEventsContext(t *testing.T) {
+	previousProvider := otel.GetTracerProvider()
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		otel.SetTracerProvider(previousProvider)
+	})
+
+	a := agent.New(agent.Definition{
+		Name:  "canceled",
+		Model: &mocks.MockModel{},
+		Prompt: func(context.Context, agent.RunInput) (gaictx.PromptBuilder, error) {
+			return &testPromptBuilder{}, nil
+		},
+	})
+	workflow, err := a.NewRun(t.Context(), agent.RunInput{
+		TraceContext: &gai.TraceContext{UserID: "canceled-user"},
+		Prompt:       gaictx.PromptInput{User: gaictx.NewTextContent("question")},
+	})
+	if err != nil {
+		t.Fatalf("NewRun failed: %v", err)
+	}
+	runCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	for range workflow.RunEvents(runCtx) {
+	}
+
+	want := map[string]bool{"agent.run": false, "agent.workflow.run": false, "loop.run": false}
+	for _, span := range recorder.Ended() {
+		if _, ok := want[span.Name()]; !ok {
+			continue
+		}
+		want[span.Name()] = true
+		if got := spanAttributeMap(span)["gai.trace.user_id"]; got != "canceled-user" {
+			t.Errorf("span %q user = %#v", span.Name(), got)
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("missing canceled span %q", name)
+		}
+	}
+}
+
+func spanAttributeMap(span sdktrace.ReadOnlySpan) map[string]any {
+	attributes := make(map[string]any, len(span.Attributes()))
+	for _, attr := range span.Attributes() {
+		attributes[string(attr.Key)] = attr.Value.AsInterface()
+	}
+	return attributes
 }
 
 type agentDebugSink struct {

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -169,6 +169,7 @@ func (w *Workflow) RunEvents(ctx context.Context) <-chan loop.Event {
 	if err := w.begin(); err != nil {
 		return failedEventStream(err)
 	}
+	ctx = applyWorkflowTraceContext(ctx, w)
 	ctx, runObs := newAgentRunObserver(ctx, w)
 	ctx, obs := newWorkflowObserver(ctx, w)
 	obs.Started(ctx)
@@ -182,6 +183,7 @@ func (w *Workflow) Run(ctx context.Context) (<-chan ai.Token, <-chan loop.Iterat
 	if err := w.begin(); err != nil {
 		return failedStream(err)
 	}
+	ctx = applyWorkflowTraceContext(ctx, w)
 	ctx, runObs := newAgentRunObserver(ctx, w)
 	ctx, obs := newWorkflowObserver(ctx, w)
 	events := w.Loop.Run(ctx)
@@ -194,6 +196,13 @@ func (w *Workflow) Run(ctx context.Context) (<-chan ai.Token, <-chan loop.Iterat
 	}
 	stream = w.captureFinal(ctx, stream, obs, runObs)
 	return stream.Tokens, stream.Statuses, stream.Errors
+}
+
+func applyWorkflowTraceContext(ctx context.Context, workflow *Workflow) context.Context {
+	if workflow == nil || workflow.result.Input.TraceContext == nil {
+		return ctx
+	}
+	return gai.WithTraceContext(ctx, *workflow.result.Input.TraceContext)
 }
 
 func loopEventsToStream(ctx context.Context, events <-chan loop.Event) Stream {
@@ -554,6 +563,17 @@ func tokenReasoning(tokens []ai.Token) string {
 
 func cloneRunInput(input RunInput) RunInput {
 	cloned := input
+	if input.TraceContext != nil {
+		traceContext := *input.TraceContext
+		traceContext.Tags = append([]string(nil), input.TraceContext.Tags...)
+		if input.TraceContext.Metadata != nil {
+			traceContext.Metadata = make(map[string]string, len(input.TraceContext.Metadata))
+			for key, value := range input.TraceContext.Metadata {
+				traceContext.Metadata[key] = value
+			}
+		}
+		cloned.TraceContext = &traceContext
+	}
 	cloned.Prompt = input.Prompt.Clone()
 	cloned.ResponseFormat = cloneResponseFormat(input.ResponseFormat)
 	if input.Meta != nil {

--- a/observability/langfuse/langfuse.go
+++ b/observability/langfuse/langfuse.go
@@ -57,7 +57,8 @@ func NewTracerProvider(ctx context.Context, config Config) (*sdktrace.TracerProv
 	if err != nil {
 		return nil, fmt.Errorf("create langfuse trace exporter: %w", err)
 	}
-	options := []sdktrace.TracerProviderOption{sdktrace.WithBatcher(exporter)}
+	batcher := sdktrace.NewBatchSpanProcessor(exporter)
+	options := []sdktrace.TracerProviderOption{sdktrace.WithSpanProcessor(NewTraceContextSpanProcessor(batcher))}
 	if serviceName := strings.TrimSpace(config.ServiceName); serviceName != "" {
 		options = append(options, sdktrace.WithResource(resource.NewWithAttributes("", attribute.String("service.name", serviceName))))
 	}

--- a/observability/langfuse/langfuse_test.go
+++ b/observability/langfuse/langfuse_test.go
@@ -6,6 +6,10 @@ import (
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/lace-ai/gai"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
 func TestNewTracerProviderRejectsMissingCredentials(t *testing.T) {
@@ -51,5 +55,64 @@ func TestNewTracerProviderSendsLangfuseIngestionVersion(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for exported span")
+	}
+}
+
+func TestTraceContextSpanProcessorMapsEveryLangfuseField(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(NewTraceContextSpanProcessor(recorder)))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	ctx := gai.WithTraceContext(t.Context(), gai.TraceContext{
+		Name:        "chat",
+		UserID:      "user-1",
+		SessionID:   "session-1",
+		Tags:        []string{"mobile", "dogfood"},
+		Release:     "2026.08",
+		Environment: "staging",
+		Metadata: map[string]string{
+			"feature":     "lace-chat",
+			"tier":        "pro",
+			"invalid_key": "hidden",
+			"invalid-key": "hidden",
+			"invalid.key": "hidden",
+		},
+	})
+	_, span := provider.Tracer("langfuse-test").Start(ctx, "child")
+	span.End()
+
+	ended := recorder.Ended()
+	if len(ended) != 1 {
+		t.Fatalf("ended spans = %d, want 1", len(ended))
+	}
+	attributes := map[string]any{}
+	for _, attr := range ended[0].Attributes() {
+		attributes[string(attr.Key)] = attr.Value.AsInterface()
+	}
+	want := map[string]string{
+		"langfuse.trace.name":             "chat",
+		"langfuse.user.id":                "user-1",
+		"langfuse.session.id":             "session-1",
+		"langfuse.release":                "2026.08",
+		"langfuse.environment":            "staging",
+		"langfuse.trace.metadata.feature": "lace-chat",
+		"langfuse.trace.metadata.tier":    "pro",
+	}
+	for key, value := range want {
+		if attributes[key] != value {
+			t.Errorf("attribute %q = %#v, want %#v", key, attributes[key], value)
+		}
+	}
+	if _, exists := attributes["langfuse.trace.release"]; exists {
+		t.Fatalf("unexpected legacy release attribute in %#v", attributes)
+	}
+	for _, key := range []string{"langfuse.trace.metadata.invalid_key", "langfuse.trace.metadata.invalid-key", "langfuse.trace.metadata.invalid.key"} {
+		if _, exists := attributes[key]; exists {
+			t.Fatalf("invalid metadata key %q was mapped: %#v", key, attributes)
+		}
+	}
+	tags, ok := attributes["langfuse.trace.tags"].([]string)
+	if !ok || len(tags) != 2 || tags[0] != "mobile" || tags[1] != "dogfood" {
+		t.Fatalf("langfuse tags = %#v", attributes["langfuse.trace.tags"])
 	}
 }

--- a/observability/langfuse/trace_context.go
+++ b/observability/langfuse/trace_context.go
@@ -1,0 +1,84 @@
+package langfuse
+
+import (
+	"context"
+	"sort"
+	"sync/atomic"
+
+	"github.com/lace-ai/gai"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// NewTraceContextSpanProcessor returns a processor that maps gai.TraceContext
+// fields to Langfuse v4 trace attributes before forwarding span lifecycle
+// calls to next. When next is nil, it only applies the attribute mapping.
+func NewTraceContextSpanProcessor(next sdktrace.SpanProcessor) sdktrace.SpanProcessor {
+	return &traceContextSpanProcessor{next: next}
+}
+
+type traceContextSpanProcessor struct {
+	next    sdktrace.SpanProcessor
+	stopped atomic.Bool
+}
+
+func (p *traceContextSpanProcessor) OnStart(parent context.Context, span sdktrace.ReadWriteSpan) {
+	if p == nil || p.stopped.Load() {
+		return
+	}
+	if traceContext, ok := gai.TraceContextFromContext(parent); ok {
+		span.SetAttributes(langfuseTraceContextAttributes(traceContext)...)
+	}
+	if p.next != nil {
+		p.next.OnStart(parent, span)
+	}
+}
+
+func (p *traceContextSpanProcessor) OnEnd(span sdktrace.ReadOnlySpan) {
+	if p == nil || p.stopped.Load() || p.next == nil {
+		return
+	}
+	p.next.OnEnd(span)
+}
+
+func (p *traceContextSpanProcessor) Shutdown(ctx context.Context) error {
+	if p == nil || !p.stopped.CompareAndSwap(false, true) || p.next == nil {
+		return nil
+	}
+	return p.next.Shutdown(ctx)
+}
+
+func (p *traceContextSpanProcessor) ForceFlush(ctx context.Context) error {
+	if p == nil || p.stopped.Load() || p.next == nil {
+		return nil
+	}
+	return p.next.ForceFlush(ctx)
+}
+
+func langfuseTraceContextAttributes(traceContext gai.TraceContext) []attribute.KeyValue {
+	attributes := make([]attribute.KeyValue, 0, 6+len(traceContext.Metadata))
+	attributes = appendLangfuseStringAttribute(attributes, "langfuse.trace.name", traceContext.Name)
+	attributes = appendLangfuseStringAttribute(attributes, "langfuse.user.id", traceContext.UserID)
+	attributes = appendLangfuseStringAttribute(attributes, "langfuse.session.id", traceContext.SessionID)
+	if len(traceContext.Tags) > 0 {
+		attributes = append(attributes, attribute.StringSlice("langfuse.trace.tags", traceContext.Tags))
+	}
+	attributes = appendLangfuseStringAttribute(attributes, "langfuse.release", traceContext.Release)
+	attributes = appendLangfuseStringAttribute(attributes, "langfuse.environment", traceContext.Environment)
+	keys := make([]string, 0, len(traceContext.Metadata))
+	for key := range traceContext.Metadata {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		attributes = append(attributes, attribute.String("langfuse.trace.metadata."+key, traceContext.Metadata[key]))
+	}
+	return attributes
+}
+
+func appendLangfuseStringAttribute(attributes []attribute.KeyValue, key, value string) []attribute.KeyValue {
+	if value == "" {
+		return attributes
+	}
+	return append(attributes, attribute.String(key, value))
+}

--- a/trace.go
+++ b/trace.go
@@ -19,6 +19,7 @@ func StartOperationSpan(ctx context.Context, tracerName string, spanPrefix strin
 		attribute.String(operationAttr, operation),
 	}
 	baseAttrs = append(baseAttrs, attrs...)
+	baseAttrs = append(baseAttrs, traceContextAttributes(ctx)...)
 
 	return otel.Tracer(tracerName).Start(ctx, spanPrefix+"."+operation, trace.WithAttributes(baseAttrs...))
 }

--- a/trace_context.go
+++ b/trace_context.go
@@ -1,0 +1,192 @@
+package gai
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+const (
+	maxTraceScalarBytes   = 200
+	maxTraceTagBytes      = 200
+	maxTraceTags          = 32
+	maxTraceMetadata      = 32
+	maxTraceMetadataKey   = 64
+	maxTraceMetadataValue = 200
+	maxTraceEnvironment   = 40
+)
+
+// TraceContext contains explicitly approved, trace-wide dimensions. It is
+// propagated through Go contexts and copied onto GAI spans, but is never added
+// to OpenTelemetry baggage or outbound request headers by GAI.
+type TraceContext struct {
+	Name        string
+	UserID      string
+	SessionID   string
+	Tags        []string
+	Release     string
+	Environment string
+	Metadata    map[string]string
+}
+
+type traceContextKey struct{}
+
+// WithTraceContext returns a child context containing a normalized defensive
+// copy of traceContext. Invalid, empty, or oversized fields are omitted.
+func WithTraceContext(ctx context.Context, traceContext TraceContext) context.Context {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return context.WithValue(ctx, traceContextKey{}, normalizeTraceContext(traceContext))
+}
+
+// TraceContextFromContext returns a defensive copy of the trace context in ctx.
+func TraceContextFromContext(ctx context.Context) (TraceContext, bool) {
+	traceContext, ok := traceContextFromContext(ctx)
+	if !ok {
+		return TraceContext{}, false
+	}
+	return cloneTraceContext(traceContext), true
+}
+
+func traceContextFromContext(ctx context.Context) (TraceContext, bool) {
+	if ctx == nil {
+		return TraceContext{}, false
+	}
+	traceContext, ok := ctx.Value(traceContextKey{}).(TraceContext)
+	return traceContext, ok
+}
+
+func normalizeTraceContext(traceContext TraceContext) TraceContext {
+	normalized := TraceContext{
+		Name:        normalizeTraceScalar(traceContext.Name, maxTraceScalarBytes),
+		UserID:      normalizeTraceScalar(traceContext.UserID, maxTraceScalarBytes),
+		SessionID:   normalizeTraceScalar(traceContext.SessionID, maxTraceScalarBytes),
+		Release:     normalizeTraceScalar(traceContext.Release, maxTraceScalarBytes),
+		Environment: normalizeTraceEnvironment(traceContext.Environment),
+	}
+	seenTags := make(map[string]struct{}, min(len(traceContext.Tags), maxTraceTags))
+	for _, tag := range traceContext.Tags {
+		tag = normalizeTraceScalar(tag, maxTraceTagBytes)
+		if tag == "" {
+			continue
+		}
+		if _, exists := seenTags[tag]; exists {
+			continue
+		}
+		if len(normalized.Tags) == maxTraceTags {
+			break
+		}
+		seenTags[tag] = struct{}{}
+		normalized.Tags = append(normalized.Tags, tag)
+	}
+
+	keys := make([]string, 0, len(traceContext.Metadata))
+	for key := range traceContext.Metadata {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		if len(normalized.Metadata) == maxTraceMetadata {
+			break
+		}
+		if !validTraceMetadataKey(key) {
+			continue
+		}
+		value := normalizeTraceScalar(traceContext.Metadata[key], maxTraceMetadataValue)
+		if value == "" {
+			continue
+		}
+		if normalized.Metadata == nil {
+			normalized.Metadata = make(map[string]string)
+		}
+		normalized.Metadata[key] = value
+	}
+	return normalized
+}
+
+func normalizeTraceScalar(value string, maxBytes int) string {
+	value = strings.TrimSpace(value)
+	if value == "" || len(value) > maxBytes || !utf8.ValidString(value) {
+		return ""
+	}
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return ""
+		}
+	}
+	return value
+}
+
+func normalizeTraceEnvironment(value string) string {
+	value = normalizeTraceScalar(value, maxTraceEnvironment)
+	if value == "" || strings.HasPrefix(value, "langfuse") {
+		return ""
+	}
+	for _, r := range value {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') && r != '-' && r != '_' {
+			return ""
+		}
+	}
+	return value
+}
+
+func validTraceMetadataKey(key string) bool {
+	if key == "" || len(key) > maxTraceMetadataKey || !utf8.ValidString(key) {
+		return false
+	}
+	for _, r := range key {
+		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') && (r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneTraceContext(traceContext TraceContext) TraceContext {
+	cloned := traceContext
+	cloned.Tags = append([]string(nil), traceContext.Tags...)
+	if traceContext.Metadata != nil {
+		cloned.Metadata = make(map[string]string, len(traceContext.Metadata))
+		for key, value := range traceContext.Metadata {
+			cloned.Metadata[key] = value
+		}
+	}
+	return cloned
+}
+
+func traceContextAttributes(ctx context.Context) []attribute.KeyValue {
+	traceContext, ok := traceContextFromContext(ctx)
+	if !ok {
+		return nil
+	}
+	attributes := make([]attribute.KeyValue, 0, 6+len(traceContext.Metadata))
+	attributes = appendTraceStringAttribute(attributes, "gai.trace.name", traceContext.Name)
+	attributes = appendTraceStringAttribute(attributes, "gai.trace.user_id", traceContext.UserID)
+	attributes = appendTraceStringAttribute(attributes, "gai.trace.session_id", traceContext.SessionID)
+	if len(traceContext.Tags) > 0 {
+		attributes = append(attributes, attribute.StringSlice("gai.trace.tags", traceContext.Tags))
+	}
+	attributes = appendTraceStringAttribute(attributes, "gai.trace.release", traceContext.Release)
+	attributes = appendTraceStringAttribute(attributes, "gai.trace.environment", traceContext.Environment)
+	keys := make([]string, 0, len(traceContext.Metadata))
+	for key := range traceContext.Metadata {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		attributes = append(attributes, attribute.String("gai.trace.metadata."+key, traceContext.Metadata[key]))
+	}
+	return attributes
+}
+
+func appendTraceStringAttribute(attributes []attribute.KeyValue, key, value string) []attribute.KeyValue {
+	if value == "" {
+		return attributes
+	}
+	return append(attributes, attribute.String(key, value))
+}

--- a/trace_context.go
+++ b/trace_context.go
@@ -24,11 +24,14 @@ const (
 // propagated through Go contexts and copied onto GAI spans, but is never added
 // to OpenTelemetry baggage or outbound request headers by GAI.
 type TraceContext struct {
-	Name        string
-	UserID      string
-	SessionID   string
-	Tags        []string
-	Release     string
+	Name      string
+	UserID    string
+	SessionID string
+	Tags      []string
+	Release   string
+	// Environment is normalized to lowercase and must otherwise contain only
+	// letters, digits, hyphens, or underscores. Values starting with "langfuse"
+	// are reserved and omitted.
 	Environment string
 	Metadata    map[string]string
 }
@@ -124,7 +127,11 @@ func normalizeTraceScalar(value string, maxBytes int) string {
 
 func normalizeTraceEnvironment(value string) string {
 	value = normalizeTraceScalar(value, maxTraceEnvironment)
-	if value == "" || strings.HasPrefix(value, "langfuse") {
+	if value == "" {
+		return ""
+	}
+	value = strings.ToLower(value)
+	if strings.HasPrefix(value, "langfuse") {
 		return ""
 	}
 	for _, r := range value {

--- a/trace_context_test.go
+++ b/trace_context_test.go
@@ -1,0 +1,187 @@
+package gai
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestTraceContextNormalizesAndCopies(t *testing.T) {
+	input := TraceContext{
+		Name:        "  chat  ",
+		UserID:      "user-1",
+		SessionID:   "session-1",
+		Tags:        []string{" alpha ", "alpha", "", "beta"},
+		Release:     " 2026.08 ",
+		Environment: "staging_1",
+		Metadata: map[string]string{
+			"tier":         " pro ",
+			"invalid key":  "hidden",
+			"invalid_key":  "hidden",
+			"invalid-key":  "hidden",
+			"invalid.key":  "hidden",
+			"empty":        "  ",
+			"oversized":    strings.Repeat("x", maxTraceMetadataValue+1),
+			"validnested1": "yes",
+		},
+	}
+	ctx := WithTraceContext(t.Context(), input)
+	input.Tags[0] = "mutated"
+	input.Metadata["tier"] = "mutated"
+
+	got, ok := TraceContextFromContext(ctx)
+	if !ok {
+		t.Fatal("trace context was not installed")
+	}
+	if got.Name != "chat" || got.UserID != "user-1" || got.SessionID != "session-1" || got.Release != "2026.08" || got.Environment != "staging_1" {
+		t.Fatalf("unexpected normalized scalars: %#v", got)
+	}
+	if strings.Join(got.Tags, ",") != "alpha,beta" {
+		t.Fatalf("normalized tags = %#v", got.Tags)
+	}
+	if len(got.Metadata) != 2 || got.Metadata["tier"] != "pro" || got.Metadata["validnested1"] != "yes" {
+		t.Fatalf("normalized metadata = %#v", got.Metadata)
+	}
+
+	got.Tags[0] = "changed"
+	got.Metadata["tier"] = "changed"
+	again, _ := TraceContextFromContext(ctx)
+	if again.Tags[0] != "alpha" || again.Metadata["tier"] != "pro" {
+		t.Fatalf("returned trace context aliases stored data: %#v", again)
+	}
+}
+
+func TestTraceContextUsesLangfuseCompatibleStringBoundaries(t *testing.T) {
+	valid := strings.Repeat("x", 200)
+	invalid := strings.Repeat("x", 201)
+	validCtx := WithTraceContext(t.Context(), TraceContext{
+		UserID:    valid,
+		SessionID: valid,
+		Tags:      []string{valid},
+		Metadata:  map[string]string{"key1": valid},
+	})
+	got, _ := TraceContextFromContext(validCtx)
+	if got.UserID != valid || got.SessionID != valid || len(got.Tags) != 1 || got.Metadata["key1"] != valid {
+		t.Fatalf("200-byte values were omitted: %#v", got)
+	}
+
+	invalidCtx := WithTraceContext(t.Context(), TraceContext{
+		UserID:    invalid,
+		SessionID: invalid,
+		Tags:      []string{invalid},
+		Metadata:  map[string]string{"key1": invalid},
+	})
+	got, _ = TraceContextFromContext(invalidCtx)
+	if got.UserID != "" || got.SessionID != "" || len(got.Tags) != 0 || len(got.Metadata) != 0 {
+		t.Fatalf("201-byte values were retained: %#v", got)
+	}
+}
+
+func TestTraceContextOmitsInvalidAndOversizedScalars(t *testing.T) {
+	ctx := WithTraceContext(t.Context(), TraceContext{
+		Name:        strings.Repeat("n", maxTraceScalarBytes+1),
+		UserID:      "user\nsecret",
+		SessionID:   string([]byte{0xff}),
+		Release:     "ok",
+		Environment: "Production",
+	})
+	got, ok := TraceContextFromContext(ctx)
+	if !ok {
+		t.Fatal("expected an installed empty trace context")
+	}
+	if got.Name != "" || got.UserID != "" || got.SessionID != "" || got.Environment != "" || got.Release != "ok" {
+		t.Fatalf("invalid values were retained: %#v", got)
+	}
+}
+
+func TestTraceContextBoundsCollectionsDeterministically(t *testing.T) {
+	tags := make([]string, maxTraceTags+2)
+	metadata := make(map[string]string, maxTraceMetadata+2)
+	for index := range tags {
+		tags[index] = fmt.Sprintf("tag-%02d", index)
+		metadata[fmt.Sprintf("key%02d", index)] = fmt.Sprintf("value-%02d", index)
+	}
+	ctx := WithTraceContext(t.Context(), TraceContext{Tags: tags, Metadata: metadata})
+	got, _ := TraceContextFromContext(ctx)
+	if len(got.Tags) != maxTraceTags || got.Tags[0] != "tag-00" || got.Tags[maxTraceTags-1] != "tag-31" {
+		t.Fatalf("bounded tags = %#v", got.Tags)
+	}
+	if len(got.Metadata) != maxTraceMetadata || got.Metadata["key00"] != "value-00" || got.Metadata["key31"] != "value-31" {
+		t.Fatalf("bounded metadata = %#v", got.Metadata)
+	}
+	if _, exists := got.Metadata["key32"]; exists {
+		t.Fatalf("metadata limit was not deterministic: %#v", got.Metadata)
+	}
+}
+
+func TestTraceContextAttributesAreDeterministic(t *testing.T) {
+	ctx := WithTraceContext(t.Context(), TraceContext{Metadata: map[string]string{"z": "last", "a": "first"}})
+	attributes := traceContextAttributes(ctx)
+	if len(attributes) != 2 || string(attributes[0].Key) != "gai.trace.metadata.a" || string(attributes[1].Key) != "gai.trace.metadata.z" {
+		t.Fatalf("metadata attributes are not sorted: %#v", attributes)
+	}
+}
+
+func TestTraceContextIsNotInjectedAsBaggage(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+
+	ctx := WithTraceContext(t.Context(), TraceContext{UserID: "user-secret", SessionID: "session-secret"})
+	ctx, span := provider.Tracer("trace-context-test").Start(ctx, "request")
+	defer span.End()
+
+	carrier := propagation.HeaderCarrier(http.Header{})
+	propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}, propagation.Baggage{}).Inject(ctx, carrier)
+	if baggage := carrier.Get("baggage"); baggage != "" {
+		t.Fatalf("trace context leaked through baggage: %q", baggage)
+	}
+	for key, values := range http.Header(carrier) {
+		joined := strings.Join(values, ",")
+		if strings.Contains(joined, "user-secret") || strings.Contains(joined, "session-secret") {
+			t.Fatalf("trace context leaked through header %q: %q", key, joined)
+		}
+	}
+}
+
+func TestStartOperationSpanCopiesTraceContextAttributesWithoutCrossContamination(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	previousProvider := otel.GetTracerProvider()
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		otel.SetTracerProvider(previousProvider)
+	})
+
+	done := make(chan struct{}, 2)
+	for _, userID := range []string{"user-a", "user-b"} {
+		go func(userID string) {
+			ctx := WithTraceContext(context.Background(), TraceContext{UserID: userID})
+			_, span := StartOperationSpan(ctx, "trace-context-test", "test", "test.operation", userID)
+			span.End()
+			done <- struct{}{}
+		}(userID)
+	}
+	<-done
+	<-done
+
+	seen := map[string]string{}
+	for _, span := range recorder.Ended() {
+		for _, attr := range span.Attributes() {
+			if string(attr.Key) == "gai.trace.user_id" {
+				seen[span.Name()] = attr.Value.AsString()
+			}
+		}
+	}
+	if seen["test.user-a"] != "user-a" || seen["test.user-b"] != "user-b" {
+		t.Fatalf("trace contexts crossed runs: %#v", seen)
+	}
+}

--- a/trace_context_test.go
+++ b/trace_context_test.go
@@ -90,7 +90,7 @@ func TestTraceContextOmitsInvalidAndOversizedScalars(t *testing.T) {
 		UserID:      "user\nsecret",
 		SessionID:   string([]byte{0xff}),
 		Release:     "ok",
-		Environment: "Production",
+		Environment: "us-east.prod",
 	})
 	got, ok := TraceContextFromContext(ctx)
 	if !ok {
@@ -98,6 +98,27 @@ func TestTraceContextOmitsInvalidAndOversizedScalars(t *testing.T) {
 	}
 	if got.Name != "" || got.UserID != "" || got.SessionID != "" || got.Environment != "" || got.Release != "ok" {
 		t.Fatalf("invalid values were retained: %#v", got)
+	}
+}
+
+func TestTraceContextNormalizesEnvironmentToLowercase(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "Production", want: "production"},
+		{input: " Staging ", want: "staging"},
+		{input: "prod-US", want: "prod-us"},
+		{input: "Langfuse-Cloud", want: ""},
+	}
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			ctx := WithTraceContext(t.Context(), TraceContext{Environment: test.input})
+			got, _ := TraceContextFromContext(ctx)
+			if got.Environment != test.want {
+				t.Fatalf("environment = %q, want %q", got.Environment, test.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #108

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `gai.TraceContext` — a validated, context-propagated struct carrying trace-wide dimensions (user ID, session ID, tags, release, environment, metadata) — and wires it end-to-end from `agent.RunInput` through OTel spans to a new Langfuse `TraceContextSpanProcessor` that maps the fields to Langfuse v4 attribute names.

- **`trace_context.go`** implements the core type: normalization (scalar byte limits, tag dedup, env lowercasing, alphanumeric-only metadata keys), defensive deep-copying on every read/write boundary, and provider-neutral `gai.trace.*` OTel attribute emission in `StartOperationSpan`.
- **`observability/langfuse/trace_context.go`** adds `NewTraceContextSpanProcessor`, a thin wrapper that reads the stored `TraceContext` at span-start time and emits `langfuse.*` attributes before forwarding to the downstream batcher — installed automatically by `NewTracerProvider`.
- **`agent/workflow.go`** re-applies the stored `TraceContext` into the caller-supplied context at the start of both `RunEvents` and `Run`, ensuring the trace dimensions survive even when a fresh (possibly already-canceled) context is passed at execution time.

<h3>Confidence Score: 5/5</h3>

Safe to merge. Changes are additive observability instrumentation with no modifications to existing data paths or auth flows.

The TraceContext pipeline is purely additive: it decorates existing spans with extra attributes and adds an opt-in field to RunInput. Defensive copying is applied consistently at every public boundary, normalization prevents invalid data from reaching Langfuse, and the test suite covers propagation through retries and tools, inherit-vs-replace atomicity, canceled-context survival, and baggage non-injection. The Langfuse provider change is a transparent mechanical rewrap of the batcher with no behavioral difference for the exporter.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| trace_context.go | New file: core TraceContext type, normalization pipeline (scalar limits, env lowercasing, metadata key validation, tag dedup), context storage, and OTel attribute emission. Well-tested with deep-copy semantics throughout. |
| observability/langfuse/trace_context.go | New file: SpanProcessor wrapper that reads gai.TraceContext from span start context and emits Langfuse v4 attribute names. Atomic stopped flag, nil-safe throughout, correctly sets attributes before forwarding to next processor. |
| observability/langfuse/langfuse.go | Modified NewTracerProvider to wrap the BatchSpanProcessor with NewTraceContextSpanProcessor; equivalent to the previous WithBatcher call but now enables Langfuse attribute injection on every span. |
| agent/agent.go | Adds TraceContext field to RunInput and resolveRunTraceContext helper that installs/inherits it before any spans are opened in NewRun. |
| agent/workflow.go | Re-applies stored TraceContext to the caller-supplied context at the start of RunEvents and Run, and deep-copies TraceContext in cloneRunInput. |
| trace.go | StartOperationSpan now appends provider-neutral gai.trace.* attributes from context to every span it creates. |
| agent/obs_test.go | Three new integration tests: propagation across retries/tools/middleware, inherit-vs-replace atomicity, and survival through a canceled RunEvents context. |
| trace_context_test.go | New file: unit tests covering normalization, boundary values, environment lowercase, collection bounding, attribute determinism, baggage non-injection, and cross-run non-contamination. |
| observability/langfuse/langfuse_test.go | Adds TestTraceContextSpanProcessorMapsEveryLangfuseField covering all Langfuse v4 attribute mappings and verifying invalid metadata keys are excluded. |
| README.md | Adds TraceContext usage example and documents allowed field formats, size limits, lowercase environment normalization, and the Langfuse span processor. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant agent.NewRun
    participant resolveRunTraceContext
    participant gai.WithTraceContext
    participant Workflow.RunEvents
    participant applyWorkflowTraceContext
    participant StartOperationSpan
    participant traceContextSpanProcessor
    participant BatchSpanProcessor
    participant Langfuse

    Caller->>agent.NewRun: "RunInput{TraceContext: &tc}"
    agent.NewRun->>resolveRunTraceContext: ctx, input
    resolveRunTraceContext->>gai.WithTraceContext: "normalizes & stores tc in ctx"
    resolveRunTraceContext-->>agent.NewRun: "ctx with tc, input.TraceContext = normalized copy"

    Caller->>Workflow.RunEvents: freshCtx (may differ from NewRun ctx)
    Workflow.RunEvents->>applyWorkflowTraceContext: re-installs stored tc into freshCtx
    Workflow.RunEvents->>StartOperationSpan: ctx with tc
    StartOperationSpan->>StartOperationSpan: "appends gai.trace.* attributes"

    Note over StartOperationSpan,traceContextSpanProcessor: OTel span.Start fires OnStart
    StartOperationSpan->>traceContextSpanProcessor: OnStart(ctx, span)
    traceContextSpanProcessor->>gai.WithTraceContext: TraceContextFromContext(ctx)
    traceContextSpanProcessor->>traceContextSpanProcessor: "SetAttributes(langfuse.*)"
    traceContextSpanProcessor->>BatchSpanProcessor: OnStart(ctx, span)
    BatchSpanProcessor->>Langfuse: "export span with both gai.trace.* and langfuse.* attrs"
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(obs) validation issue"](https://github.com/lace-ai/gai/commit/b93bcfb54d387b2a2c69acd868ac1a8e132a3072) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49305902)</sub>

<!-- /greptile_comment -->