### PR TITLE
feat: emit provider streaming completion metadata

### DIFF
--- a/ai/anthropic/model.go
+++ b/ai/anthropic/model.go
@@ -49,7 +49,7 @@ func anthropicAdapterDescriptor(model string) ai.ModelDescriptor {
 	return ai.ModelDescriptor{Model: model, NativeMessages: ai.FeatureSupportSupported, NativeTools: ai.FeatureSupportSupported,
 		ToolChoiceModes: []ai.ToolChoiceMode{ai.ToolChoiceAuto, ai.ToolChoiceNone, ai.ToolChoiceRequired},
 		Multimodal:      ai.FeatureSupportUnsupported,
-		Usage:           ai.FeatureSupportSupported, FinishReason: ai.FeatureSupportSupported, StreamingUsage: ai.FeatureSupportUnsupported,
+		Usage:           ai.FeatureSupportSupported, FinishReason: ai.FeatureSupportSupported, StreamingUsage: ai.FeatureSupportSupported,
 		ToolCalling: ai.FeatureSupportSupported,
 		JSONOutput:  ai.FeatureSupportUnsupported, JSONSchemaOutput: ai.FeatureSupportSupported,
 		Reasoning: ai.FeatureSupportSupported, ReasoningEffort: ai.FeatureSupportSupported,
@@ -397,9 +397,28 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 		stream := client.Messages.NewStreaming(ctx, payload)
 		defer stream.Close()
 		blocks := map[int64]*streamBlock{}
+		completion := ai.Completion{Provider: "anthropic"}
 		for stream.Next() {
 			event := stream.Current()
 			switch event.Type {
+			case "message_start":
+				completion.RequestID = event.Message.ID
+				completion.Model = string(event.Message.Model)
+			case "message_delta":
+				completion.Usage = ai.Usage{
+					InputTokens:         int(event.Usage.InputTokens + event.Usage.CacheCreationInputTokens + event.Usage.CacheReadInputTokens),
+					OutputTokens:        int(event.Usage.OutputTokens),
+					ReasoningTokens:     int(event.Usage.OutputTokensDetails.ThinkingTokens),
+					CachedTokens:        int(event.Usage.CacheReadInputTokens),
+					CacheCreationTokens: int(event.Usage.CacheCreationInputTokens),
+				}
+				completion.FinishReason = string(event.Delta.StopReason)
+				completion.Raw = append(completion.Raw[:0], []byte(event.RawJSON())...)
+				snapshot := completion
+				snapshot.Raw = append(json.RawMessage(nil), completion.Raw...)
+				if !emit(ai.Token{Type: ai.TokenTypeCompletion, Completion: &snapshot}) {
+					return
+				}
 			case "content_block_start":
 				blocks[event.Index] = &streamBlock{typ: event.ContentBlock.Type, id: event.ContentBlock.ID, name: event.ContentBlock.Name}
 			case "content_block_delta":

--- a/ai/anthropic/model_test.go
+++ b/ai/anthropic/model_test.go
@@ -285,6 +285,26 @@ func TestGenerateStreamMapsInterleavedBlocksAndToolJSON(t *testing.T) {
 	}
 }
 
+func TestGenerateStreamEmitsTerminalCompletionSnapshot(t *testing.T) {
+	m := testModel(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"model\":\"claude-test\"}}\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":10,\"cache_creation_input_tokens\":2,\"cache_read_input_tokens\":3,\"output_tokens\":4,\"output_tokens_details\":{\"thinking_tokens\":1}}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"))
+	})
+
+	var completion *ai.Completion
+	for token := range m.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+		if token.Type == ai.TokenTypeCompletion {
+			completion = token.Completion
+		}
+	}
+	if completion == nil || completion.Provider != "anthropic" || completion.RequestID != "msg_1" || completion.Model != "claude-test" || completion.FinishReason != "end_turn" {
+		t.Fatalf("completion = %#v", completion)
+	}
+	if completion.Usage.InputTokens != 15 || completion.Usage.OutputTokens != 4 || completion.Usage.ReasoningTokens != 1 || completion.Usage.CachedTokens != 3 || completion.Usage.CacheCreationTokens != 2 || !json.Valid(completion.Raw) {
+		t.Fatalf("completion usage = %#v, raw = %q", completion.Usage, completion.Raw)
+	}
+}
+
 func TestGenerateStreamErrorAndCancellation(t *testing.T) {
 	m := testModel(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/ai/gemini/model.go
+++ b/ai/gemini/model.go
@@ -158,13 +158,16 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			if resp == nil {
 				continue
 			}
+			responseHasCompletion := false
 			if resp.ResponseID != "" {
 				completion.RequestID = resp.ResponseID
 				hasCompletion = true
+				responseHasCompletion = true
 			}
 			if resp.ModelVersion != "" {
 				completion.Model = resp.ModelVersion
 				hasCompletion = true
+				responseHasCompletion = true
 			}
 			if resp.UsageMetadata != nil {
 				completion.Usage = ai.Usage{
@@ -175,12 +178,14 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 					ToolUseTokens:   int(resp.UsageMetadata.ToolUsePromptTokenCount),
 				}
 				hasCompletion = true
+				responseHasCompletion = true
 			}
 			if len(resp.Candidates) > 0 && resp.Candidates[0] != nil && resp.Candidates[0].FinishReason != "" {
 				completion.FinishReason = string(resp.Candidates[0].FinishReason)
 				hasCompletion = true
+				responseHasCompletion = true
 			}
-			if hasCompletion {
+			if responseHasCompletion {
 				raw, marshalErr := json.Marshal(resp)
 				if marshalErr != nil {
 					streamErr = fmt.Errorf("encode Gemini completion metadata: %w", marshalErr)

--- a/ai/gemini/model.go
+++ b/ai/gemini/model.go
@@ -51,7 +51,7 @@ func geminiAdapterDescriptor(model string) ai.ModelDescriptor {
 	return ai.ModelDescriptor{Model: model, NativeMessages: ai.FeatureSupportSupported, NativeTools: ai.FeatureSupportSupported,
 		ToolChoiceModes: []ai.ToolChoiceMode{ai.ToolChoiceAuto, ai.ToolChoiceNone, ai.ToolChoiceRequired},
 		Multimodal:      ai.FeatureSupportUnsupported,
-		Usage:           ai.FeatureSupportSupported, FinishReason: ai.FeatureSupportUnsupported, StreamingUsage: ai.FeatureSupportUnsupported,
+		Usage:           ai.FeatureSupportSupported, FinishReason: ai.FeatureSupportSupported, StreamingUsage: ai.FeatureSupportSupported,
 		ToolCalling: ai.FeatureSupportSupported,
 		JSONOutput:  ai.FeatureSupportSupported, JSONSchemaOutput: ai.FeatureSupportSupported,
 		Reasoning: ai.FeatureSupportSupported, ReasoningEffort: ai.FeatureSupportSupported, ReasoningEfforts: []ai.ReasoningEffort{ai.ReasoningEffortLow, ai.ReasoningEffortMedium, ai.ReasoningEffortHigh},
@@ -136,6 +136,8 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			return
 		}
 
+		completion := ai.Completion{Provider: "gemini"}
+		hasCompletion := false
 		for resp, err := range client.Models.GenerateContentStream(ctx, m.name, contents, config) {
 			if err != nil {
 				streamErr = fmt.Errorf("error generating content stream: %w", err)
@@ -153,7 +155,40 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 				return
 			}
 
-			if resp == nil || len(resp.Candidates) == 0 || resp.Candidates[0] == nil || resp.Candidates[0].Content == nil {
+			if resp == nil {
+				continue
+			}
+			if resp.ResponseID != "" {
+				completion.RequestID = resp.ResponseID
+			}
+			if resp.ModelVersion != "" {
+				completion.Model = resp.ModelVersion
+			}
+			if resp.UsageMetadata != nil {
+				completion.Usage = ai.Usage{
+					InputTokens:     int(resp.UsageMetadata.PromptTokenCount),
+					OutputTokens:    int(resp.UsageMetadata.CandidatesTokenCount),
+					ReasoningTokens: int(resp.UsageMetadata.ThoughtsTokenCount),
+					CachedTokens:    int(resp.UsageMetadata.CachedContentTokenCount),
+					ToolUseTokens:   int(resp.UsageMetadata.ToolUsePromptTokenCount),
+				}
+				hasCompletion = true
+			}
+			if len(resp.Candidates) > 0 && resp.Candidates[0] != nil && resp.Candidates[0].FinishReason != "" {
+				completion.FinishReason = string(resp.Candidates[0].FinishReason)
+				hasCompletion = true
+			}
+			if hasCompletion {
+				raw, marshalErr := json.Marshal(resp)
+				if marshalErr != nil {
+					streamErr = fmt.Errorf("encode Gemini completion metadata: %w", marshalErr)
+					ai.SendToken(ctx, out, ai.Token{Err: streamErr, Type: ai.TokenTypeErr, Text: streamErr.Error()})
+					return
+				}
+				completion.Raw = append(completion.Raw[:0], raw...)
+			}
+
+			if len(resp.Candidates) == 0 || resp.Candidates[0] == nil || resp.Candidates[0].Content == nil {
 				continue
 			}
 
@@ -241,6 +276,11 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 					toolCallCount++
 				}
 			}
+		}
+		if hasCompletion {
+			snapshot := completion
+			snapshot.Raw = append(json.RawMessage(nil), completion.Raw...)
+			ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeCompletion, Completion: &snapshot})
 		}
 	}()
 

--- a/ai/gemini/model.go
+++ b/ai/gemini/model.go
@@ -160,9 +160,11 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			}
 			if resp.ResponseID != "" {
 				completion.RequestID = resp.ResponseID
+				hasCompletion = true
 			}
 			if resp.ModelVersion != "" {
 				completion.Model = resp.ModelVersion
+				hasCompletion = true
 			}
 			if resp.UsageMetadata != nil {
 				completion.Usage = ai.Usage{

--- a/ai/gemini/model_test.go
+++ b/ai/gemini/model_test.go
@@ -30,6 +30,38 @@ func TestModelDescriptorRejectsUnknownReasoningEffortBeforeTransport(t *testing.
 	}
 }
 
+func TestModelGenerateStreamEmitsCompletionForIdentityMetadata(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"responseId\":\"resp_1\",\"modelVersion\":\"gemini-test\"}\n\n"))
+	}))
+	defer server.Close()
+
+	provider := New("test-api-key", nil)
+	provider.baseURL = server.URL
+	provider.httpClient = server.Client()
+	model, err := provider.Model("gemini-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var completion *ai.Completion
+	for token := range model.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+		if token.Err != nil {
+			t.Fatalf("unexpected stream error: %v", token.Err)
+		}
+		if token.Type == ai.TokenTypeCompletion {
+			completion = token.Completion
+		}
+	}
+	if completion == nil || completion.Provider != "gemini" || completion.RequestID != "resp_1" || completion.Model != "gemini-test" || !json.Valid(completion.Raw) {
+		t.Fatalf("completion = %#v", completion)
+	}
+}
+
 func TestMapFunctionCall(t *testing.T) {
 	got, err := mapFunctionCall(&genai.FunctionCall{
 		ID:   "call_1",

--- a/ai/gemini/model_test.go
+++ b/ai/gemini/model_test.go
@@ -37,6 +37,7 @@ func TestModelGenerateStreamEmitsCompletionForIdentityMetadata(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte("data: {\"responseId\":\"resp_1\",\"modelVersion\":\"gemini-test\"}\n\n"))
+		_, _ = w.Write([]byte("data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"hello\"}]}}]}\n\n"))
 	}))
 	defer server.Close()
 
@@ -59,6 +60,15 @@ func TestModelGenerateStreamEmitsCompletionForIdentityMetadata(t *testing.T) {
 	}
 	if completion == nil || completion.Provider != "gemini" || completion.RequestID != "resp_1" || completion.Model != "gemini-test" || !json.Valid(completion.Raw) {
 		t.Fatalf("completion = %#v", completion)
+	}
+	var raw struct {
+		ResponseID string `json:"responseId"`
+	}
+	if err := json.Unmarshal(completion.Raw, &raw); err != nil {
+		t.Fatalf("unmarshal completion raw: %v", err)
+	}
+	if raw.ResponseID != "resp_1" {
+		t.Fatalf("completion raw responseId = %q, want resp_1", raw.ResponseID)
 	}
 }
 

--- a/ai/mistral/model.go
+++ b/ai/mistral/model.go
@@ -714,9 +714,11 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			}
 			if chunk.ID != "" {
 				completion.RequestID = chunk.ID
+				hasCompletion = true
 			}
 			if chunk.Model != "" {
 				completion.Model = chunk.Model
+				hasCompletion = true
 			}
 			if chunk.Usage != nil {
 				completion.Usage = ai.Usage{InputTokens: chunk.Usage.PromptTokens, OutputTokens: chunk.Usage.CompletionTokens}

--- a/ai/mistral/model.go
+++ b/ai/mistral/model.go
@@ -53,7 +53,7 @@ func mistralAdapterDescriptor(model string) ai.ModelDescriptor {
 	return ai.ModelDescriptor{Model: model, NativeMessages: ai.FeatureSupportSupported, NativeTools: ai.FeatureSupportSupported,
 		ToolChoiceModes: []ai.ToolChoiceMode{ai.ToolChoiceAuto, ai.ToolChoiceNone, ai.ToolChoiceRequired},
 		Multimodal:      ai.FeatureSupportUnsupported,
-		Usage:           ai.FeatureSupportSupported, FinishReason: ai.FeatureSupportSupported, StreamingUsage: ai.FeatureSupportUnsupported,
+		Usage:           ai.FeatureSupportSupported, FinishReason: ai.FeatureSupportSupported, StreamingUsage: ai.FeatureSupportSupported,
 		ToolCalling: ai.FeatureSupportSupported,
 		JSONOutput:  ai.FeatureSupportSupported, JSONSchemaOutput: ai.FeatureSupportSupported,
 		Reasoning: ai.FeatureSupportUnsupported, ReasoningEffort: ai.FeatureSupportUnsupported,
@@ -72,6 +72,11 @@ type chatCompletionRequest struct {
 	Tools          []chatToolRequest    `json:"tools,omitempty"`
 	ToolChoice     any                  `json:"tool_choice,omitempty"`
 	ResponseFormat *chatResponseFormat  `json:"response_format,omitempty"`
+	StreamOptions  *chatStreamOptions   `json:"stream_options,omitempty"`
+}
+
+type chatStreamOptions struct {
+	IncludeUsage bool `json:"include_usage"`
 }
 
 type chatMessageRequest struct {
@@ -141,6 +146,9 @@ func buildChatCompletionRequest(req ai.AIRequest, modelName string, stream bool)
 			},
 		},
 		Stream: stream,
+	}
+	if stream {
+		payload.StreamOptions = &chatStreamOptions{IncludeUsage: true}
 	}
 	if len(req.Messages) > 0 {
 		payload.Messages = mapNativeMessages(req.Messages)
@@ -365,6 +373,8 @@ func (t *Tokenizer) CountTokens(ctx context.Context, text string) (tokens int, e
 }
 
 type chatCompletionStreamResponse struct {
+	ID      string `json:"id"`
+	Model   string `json:"model"`
 	Choices []struct {
 		Delta struct {
 			Content   json.RawMessage `json:"content"`
@@ -372,6 +382,10 @@ type chatCompletionStreamResponse struct {
 		} `json:"delta"`
 		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
+	Usage *struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+	} `json:"usage"`
 }
 
 type mistralStreamFunctionCall struct {
@@ -657,6 +671,20 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 		reader := bufio.NewReader(res.Body)
 		var eventData strings.Builder
 		var toolCallAccumulator mistralToolCallAccumulator
+		completion := ai.Completion{Provider: "mistral"}
+		hasCompletion := false
+		emitCompletion := func() error {
+			if !hasCompletion {
+				return nil
+			}
+			snapshot := completion
+			snapshot.Raw = append(json.RawMessage(nil), completion.Raw...)
+			if !emit(ai.Token{Type: ai.TokenTypeCompletion, Completion: &snapshot}) {
+				return ctx.Err()
+			}
+			hasCompletion = false
+			return nil
+		}
 
 		flushEvent := func() error {
 			event := strings.TrimSpace(eventData.String())
@@ -674,6 +702,9 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 						return ctx.Err()
 					}
 				}
+				if err := emitCompletion(); err != nil {
+					return err
+				}
 				return io.EOF
 			}
 
@@ -681,8 +712,28 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			if err := json.Unmarshal([]byte(event), &chunk); err != nil {
 				return fmt.Errorf("decode stream chunk: %w", err)
 			}
+			if chunk.ID != "" {
+				completion.RequestID = chunk.ID
+			}
+			if chunk.Model != "" {
+				completion.Model = chunk.Model
+			}
+			if chunk.Usage != nil {
+				completion.Usage = ai.Usage{InputTokens: chunk.Usage.PromptTokens, OutputTokens: chunk.Usage.CompletionTokens}
+				hasCompletion = true
+			}
 			if len(chunk.Choices) == 0 {
+				if hasCompletion {
+					completion.Raw = append(completion.Raw[:0], []byte(event)...)
+				}
 				return nil
+			}
+			if chunk.Choices[0].FinishReason != "" {
+				completion.FinishReason = chunk.Choices[0].FinishReason
+				hasCompletion = true
+			}
+			if hasCompletion {
+				completion.Raw = append(completion.Raw[:0], []byte(event)...)
 			}
 
 			text, err := extractStreamText(chunk.Choices[0].Delta.Content)

--- a/ai/mistral/model_test.go
+++ b/ai/mistral/model_test.go
@@ -513,6 +513,37 @@ func TestModelGenerateStream(t *testing.T) {
 	}
 }
 
+func TestModelGenerateStreamEmitsTerminalCompletion(t *testing.T) {
+	var gotReq chatCompletionRequest
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: {\"id\":\"cmpl_1\",\"model\":\"mistral-test\",\"choices\":[{\"delta\":{\"content\":\"ok\"},\"finish_reason\":\"stop\"}]}\n\ndata: {\"id\":\"cmpl_1\",\"model\":\"mistral-test\",\"choices\":[],\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":3}}\n\ndata: [DONE]\n\n")
+	}))
+	defer ts.Close()
+	p := New("test-key", nil)
+	p.baseURL = ts.URL
+	m, err := p.Model(MistralSmallLatest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var completion *ai.Completion
+	for token := range m.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+		if token.Type == ai.TokenTypeCompletion {
+			completion = token.Completion
+		}
+	}
+	if gotReq.StreamOptions == nil || !gotReq.StreamOptions.IncludeUsage {
+		t.Fatalf("stream options = %#v", gotReq.StreamOptions)
+	}
+	if completion == nil || completion.Provider != "mistral" || completion.RequestID != "cmpl_1" || completion.Model != "mistral-test" || completion.FinishReason != "stop" || completion.Usage.InputTokens != 7 || completion.Usage.OutputTokens != 3 || !json.Valid(completion.Raw) {
+		t.Fatalf("completion = %#v", completion)
+	}
+}
+
 func TestModelGenerateStreamToolCall(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/ai/mistral/model_test.go
+++ b/ai/mistral/model_test.go
@@ -544,6 +544,33 @@ func TestModelGenerateStreamEmitsTerminalCompletion(t *testing.T) {
 	}
 }
 
+func TestModelGenerateStreamEmitsCompletionForIdentityMetadata(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: {\"id\":\"cmpl_1\",\"model\":\"mistral-test\",\"choices\":[]}\n\ndata: [DONE]\n\n")
+	}))
+	defer ts.Close()
+	p := New("test-key", nil)
+	p.baseURL = ts.URL
+	m, err := p.Model(MistralSmallLatest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var completion *ai.Completion
+	for token := range m.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+		if token.Err != nil {
+			t.Fatalf("unexpected stream error: %v", token.Err)
+		}
+		if token.Type == ai.TokenTypeCompletion {
+			completion = token.Completion
+		}
+	}
+	if completion == nil || completion.Provider != "mistral" || completion.RequestID != "cmpl_1" || completion.Model != "mistral-test" || !json.Valid(completion.Raw) {
+		t.Fatalf("completion = %#v", completion)
+	}
+}
+
 func TestModelGenerateStreamToolCall(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/ai/response.go
+++ b/ai/response.go
@@ -27,10 +27,12 @@ type AIResponse struct {
 
 // Usage is normalized provider token accounting for one completed request.
 type Usage struct {
-	InputTokens     int
-	OutputTokens    int
-	ReasoningTokens int
-	CachedTokens    int
+	InputTokens         int
+	OutputTokens        int
+	ReasoningTokens     int
+	CachedTokens        int
+	CacheCreationTokens int
+	ToolUseTokens       int
 }
 
 // Add accumulates another provider usage record.
@@ -39,6 +41,8 @@ func (u *Usage) Add(other Usage) {
 	u.OutputTokens += other.OutputTokens
 	u.ReasoningTokens += other.ReasoningTokens
 	u.CachedTokens += other.CachedTokens
+	u.CacheCreationTokens += other.CacheCreationTokens
+	u.ToolUseTokens += other.ToolUseTokens
 }
 
 // Completion is terminal metadata emitted by a streaming provider request.

--- a/ai/response_test.go
+++ b/ai/response_test.go
@@ -65,6 +65,14 @@ func TestAIResponseAppendTokenCompletionUsesLatestUsage(t *testing.T) {
 	}
 }
 
+func TestUsageAddPreservesProviderSpecificBreakdowns(t *testing.T) {
+	usage := ai.Usage{InputTokens: 1, CachedTokens: 2, CacheCreationTokens: 3, ToolUseTokens: 4}
+	usage.Add(ai.Usage{InputTokens: 5, CachedTokens: 6, CacheCreationTokens: 7, ToolUseTokens: 8})
+	if usage.InputTokens != 6 || usage.CachedTokens != 8 || usage.CacheCreationTokens != 10 || usage.ToolUseTokens != 12 {
+		t.Fatalf("usage = %#v", usage)
+	}
+}
+
 type expectedWrapToken struct {
 	typ          ai.TokenType
 	data         string


### PR DESCRIPTION
Closes #113

Implements terminal `TokenTypeCompletion` snapshots for Anthropic, Gemini, and Mistral streams. Mistral requests stream usage; the normalized `ai.Usage` now also preserves cache-creation and tool-use token counts when exposed.

Validation:
- `go test ./...`
- `go vet ./...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Streaming responses from Anthropic, Gemini, and Mistral now include completion metadata such as request ID, model, finish reason, token usage, and raw response details.
  - Streaming usage reporting is now supported across these providers.
  - Usage tracking now includes cache-creation and tool-use token counts.
- **Improvements**
  - Completion information is reliably emitted when streaming ends, including final usage totals and provider-specific metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds terminal `TokenTypeCompletion` snapshot emission to Anthropic, Gemini, and Mistral streaming paths, and extends the normalized `Usage` struct with `CacheCreationTokens` and `ToolUseTokens`. Gemini and Mistral implementations are correct, but the Anthropic handler reads input/cache token counts from the wrong streaming event.

- **Gemini**: accumulates metadata per-chunk with a `responseHasCompletion` flag and emits one snapshot after the loop; the `Raw` over-write issue from the previous review is addressed.
- **Mistral**: adds `stream_options.include_usage`, accumulates state across chunks, and emits once on `[DONE]`; logic is sound.
- **Anthropic**: reads `InputTokens`, `CacheCreationInputTokens`, and `CacheReadInputTokens` from `message_delta.usage`, but the Anthropic API delivers these only on `message_start.message.usage` for standard requests — they are always 0 in `message_delta` without server tool use. The test passes only because it injects these fields into the mock `message_delta` payload, which does not reflect real API behavior.

<h3>Confidence Score: 4/5</h3>

Safe to merge for Gemini and Mistral; the Anthropic streaming path will report zero input tokens in production until the message_start extraction is added.

The Anthropic handler builds the Usage struct exclusively from message_delta, but the real Anthropic API reports input_tokens, cache_creation_input_tokens, and cache_read_input_tokens on message_start. A standard production request will therefore produce a Completion with InputTokens=0, CachedTokens=0, and CacheCreationTokens=0. The test masks this by placing those fields in the mock message_delta event, which the actual API never does for a standard request.

**Files Needing Attention:** ai/anthropic/model.go and ai/anthropic/model_test.go — the message_start branch needs to capture input-side token counts, and the test needs a message_start event with real usage fields.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ai/anthropic/model.go | Adds message_start / message_delta handlers to populate a Completion snapshot; input/cache token counts are incorrectly read from message_delta instead of message_start, so they will be 0 for standard production requests |
| ai/anthropic/model_test.go | New test covers the completion snapshot path but uses synthetic mock data that puts input_tokens in message_delta, masking the production bug |
| ai/gemini/model.go | Accumulates completion metadata per-response using responseHasCompletion flag, emits a single snapshot after the loop; Raw update gating addresses the previous reviewer concern |
| ai/mistral/model.go | Adds StreamOptions.include_usage, accumulates per-chunk completion state, and emits once on [DONE]; logic is correct |
| ai/response.go | Adds CacheCreationTokens and ToolUseTokens to Usage with correct Add() accumulation; AppendToken doesn't propagate the new fields to AIResponse, widening the existing gap |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant S as Streaming Provider
    participant H as Provider Handler
    participant C as ai.Completion

    Note over S,C: Anthropic
    S->>H: "message_start {id, model, usage{input_tokens, cache_*}}"
    H->>C: set RequestID, Model (input tokens NOT captured)
    S->>H: content_block_start / content_block_delta / content_block_stop
    H-->>H: emit TokenTypeText / TokenTypeToolCall
    S->>H: "message_delta {stop_reason, usage{output_tokens only}}"
    H->>C: set FinishReason, OutputTokens, Raw
    H-->>H: "emit TokenTypeCompletion (InputTokens=0 in production)"

    Note over S,C: Gemini
    S->>H: "chunk {responseId?, modelVersion?, usageMetadata?, finishReason?}"
    H->>C: accumulate metadata (responseHasCompletion gates Raw update)
    S->>H: text chunk (no metadata)
    H-->>H: emit TokenTypeText (Raw not overwritten)
    Note over H: after loop
    H-->>H: emit TokenTypeCompletion (single snapshot)

    Note over S,C: Mistral
    S->>H: "chunk {id, model, choices[{text, finish_reason}]}"
    H->>C: set RequestID, Model, FinishReason, Raw
    S->>H: "usage chunk {id, model, choices:[], usage{prompt,completion}}"
    H->>C: set Usage, Raw (overwrite with usage-bearing chunk)
    S->>H: [DONE]
    H-->>H: emit TokenTypeCompletion (single snapshot)
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(gemini): retain metadata completion ..."](https://github.com/lace-ai/gai/commit/eb9281e7c134164d417c2fa7a2549c583888bfa4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49307919)</sub>

<!-- /greptile_comment -->