### PR TITLE
add usage data to langfuse traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,20 @@ span. Applications assembling their own Langfuse tracer provider can wrap a
 span processor with `langfuse.NewTraceContextSpanProcessor` to use the same
 mapping.
 
+Every OpenAI, Mistral, Gemini, and Anthropic model invocation also creates one
+`chat {requested_model}` client span. Streaming spans remain open until the
+stream ends or is canceled. They use the same `gen_ai.*` contract for requested
+and resolved models, finish reasons, request IDs, reported token usage, and
+provider HTTP status. Langfuse generation type, model parameters, usage
+details, and completion-start time are included where known. Prompts,
+completions, reasoning, tool arguments, and raw provider payloads are not
+attached to these spans.
+
+The older `ai.provider`, `ai.model`, `ai.max_tokens`, `ai.input_tokens`,
+`ai.output_tokens`, `ai.reasoning_tokens`, and `ai.tool_call_count` attributes
+remain during the semantic-attribute migration. New integrations should use
+the `gen_ai.*` attributes.
+
 ## Package map
 
 ```text

--- a/ai/anthropic/model.go
+++ b/ai/anthropic/model.go
@@ -284,8 +284,6 @@ func mapResponseFormat(format ai.ResponseFormat) (*antropic.OutputConfigParam, e
 }
 
 func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (response *ai.AIResponse, err error) {
-	ctx, span := gai.StartOperationSpan(ctx, anthropicTracerName, "ai.anthropic", "ai.operation", "model.generate", attribute.String("ai.provider", "anthropic"), attribute.String("ai.model", m.name), attribute.Int("ai.max_tokens", req.MaxTokens), attribute.Int("ai.prompt_length", len(req.Prompt)))
-	defer func() { gai.EndSpan(span, err) }()
 	if err := ai.ValidateModelRequest(m, req); err != nil {
 		return nil, err
 	}
@@ -302,6 +300,13 @@ func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (response *ai.AI
 		m.debug.Emit(ctx, gai.DebugEvent{Name: "anthropic_generate_request", Source: "ai:anthropic.Model.Generate", Fields: fields})
 	}
 	client := m.client.sdkClient()
+	ctx, observation := ai.StartGenerationObservation(ctx, req, ai.GenerationConfig{Provider: "anthropic", Model: m.name})
+	generationResult := ai.GenerationResult{}
+	defer func() {
+		generationResult.Err = err
+		generationResult.HTTPStatus = anthropicHTTPStatus(err)
+		observation.Finish(generationResult)
+	}()
 	message, err := client.Messages.New(ctx, payload)
 	if err != nil {
 		return nil, localError(err)
@@ -312,7 +317,18 @@ func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (response *ai.AI
 	}
 	input := int(message.Usage.InputTokens + message.Usage.CacheCreationInputTokens + message.Usage.CacheReadInputTokens)
 	output := int(message.Usage.OutputTokens)
-	span.SetAttributes(attribute.Int("ai.input_tokens", input), attribute.Int("ai.output_tokens", output))
+	usage := ai.Usage{
+		InputTokens: input, OutputTokens: output,
+		ReasoningTokens: int(message.Usage.OutputTokensDetails.ThinkingTokens),
+		CachedTokens:    int(message.Usage.CacheReadInputTokens), CacheCreationTokens: int(message.Usage.CacheCreationInputTokens),
+	}
+	generationResult.ResponseModel = string(message.Model)
+	generationResult.RequestID = message.ID
+	generationResult.FinishReason = string(message.StopReason)
+	generationResult.ToolCallCount = len(calls)
+	if message.JSON.Usage.Valid() {
+		generationResult.Usage = &usage
+	}
 	if m.debug != nil {
 		fields := map[string]any{"input_tokens": input, "output_tokens": output}
 		if _, hasPolicy := gai.ContentCapturePolicyFromContext(ctx); !hasPolicy && m.debug.IncludeSensitiveData() {
@@ -322,7 +338,7 @@ func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (response *ai.AI
 		gai.AddDebugContent(ctx, m.debug, fields, "reasoning", gai.ContentKindReasoning, thinking)
 		m.debug.Emit(ctx, gai.DebugEvent{Name: "anthropic_generate_success", Source: "ai:anthropic.Model.Generate", Fields: fields})
 	}
-	return &ai.AIResponse{Text: text, Reasoning: thinking, ToolCalls: calls, Raw: json.RawMessage(message.RawJSON()), FinishReason: string(message.StopReason), InputTokens: input, OutputTokens: output, ReasoningTokens: int(message.Usage.OutputTokensDetails.ThinkingTokens)}, nil
+	return &ai.AIResponse{Text: text, Reasoning: thinking, ToolCalls: calls, Raw: json.RawMessage(message.RawJSON()), FinishReason: string(message.StopReason), InputTokens: input, OutputTokens: output, ReasoningTokens: usage.ReasoningTokens}, nil
 }
 
 func mapMessageContent(blocks []antropic.ContentBlockUnion) (string, string, []ai.ToolCall, error) {
@@ -372,10 +388,18 @@ func localError(err error) error {
 func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.Token {
 	out := make(chan ai.Token, 1)
 	go func() {
-		ctx, span := gai.StartOperationSpan(ctx, anthropicTracerName, "ai.anthropic", "ai.operation", "model.generate_stream", attribute.String("ai.provider", "anthropic"), attribute.String("ai.model", m.name), attribute.Int("ai.max_tokens", req.MaxTokens), attribute.Int("ai.prompt_length", len(req.Prompt)))
+		ctx := ctx
 		var streamErr error
-		defer func() { gai.EndSpan(span, streamErr); close(out) }()
+		var observation *ai.GenerationObservation
+		generationResult := ai.GenerationResult{}
+		defer func() {
+			generationResult.Err = streamErr
+			generationResult.HTTPStatus = anthropicHTTPStatus(streamErr)
+			observation.Finish(generationResult)
+			close(out)
+		}()
 		emit := func(token ai.Token) bool {
+			observation.ObserveToken(token)
 			if ai.SendToken(ctx, out, token) {
 				return true
 			}
@@ -394,7 +418,10 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			return
 		}
 		client := m.client.sdkClient()
-		stream := client.Messages.NewStreaming(ctx, payload)
+		generationCtx, startedObservation := ai.StartGenerationObservation(ctx, req, ai.GenerationConfig{Provider: "anthropic", Model: m.name, Streaming: true})
+		observation = startedObservation
+		ctx = generationCtx
+		stream := client.Messages.NewStreaming(generationCtx, payload)
 		defer stream.Close()
 		blocks := map[int64]*streamBlock{}
 		completion := ai.Completion{Provider: "anthropic"}
@@ -404,13 +431,24 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			case "message_start":
 				completion.RequestID = event.Message.ID
 				completion.Model = string(event.Message.Model)
+				if event.Message.JSON.Usage.Valid() {
+					completion.UsageReported = true
+					completion.Usage.InputTokens = int(event.Message.Usage.InputTokens + event.Message.Usage.CacheCreationInputTokens + event.Message.Usage.CacheReadInputTokens)
+					completion.Usage.CachedTokens = int(event.Message.Usage.CacheReadInputTokens)
+					completion.Usage.CacheCreationTokens = int(event.Message.Usage.CacheCreationInputTokens)
+				}
 			case "message_delta":
-				completion.Usage = ai.Usage{
-					InputTokens:         int(event.Usage.InputTokens + event.Usage.CacheCreationInputTokens + event.Usage.CacheReadInputTokens),
-					OutputTokens:        int(event.Usage.OutputTokens),
-					ReasoningTokens:     int(event.Usage.OutputTokensDetails.ThinkingTokens),
-					CachedTokens:        int(event.Usage.CacheReadInputTokens),
-					CacheCreationTokens: int(event.Usage.CacheCreationInputTokens),
+				completion.UsageReported = true
+				if input := int(event.Usage.InputTokens + event.Usage.CacheCreationInputTokens + event.Usage.CacheReadInputTokens); input != 0 {
+					completion.Usage.InputTokens = input
+				}
+				completion.Usage.OutputTokens = int(event.Usage.OutputTokens)
+				completion.Usage.ReasoningTokens = int(event.Usage.OutputTokensDetails.ThinkingTokens)
+				if event.Usage.CacheReadInputTokens != 0 {
+					completion.Usage.CachedTokens = int(event.Usage.CacheReadInputTokens)
+				}
+				if event.Usage.CacheCreationInputTokens != 0 {
+					completion.Usage.CacheCreationTokens = int(event.Usage.CacheCreationInputTokens)
 				}
 				completion.FinishReason = string(event.Delta.StopReason)
 				completion.Raw = append(completion.Raw[:0], []byte(event.RawJSON())...)
@@ -496,6 +534,14 @@ func streamToolCall(block *streamBlock) (*ai.ToolCall, error) {
 		id = ai.GenerateToolCallID(name)
 	}
 	return &ai.ToolCall{ID: id, Type: "function", Name: name, Args: append(json.RawMessage(nil), args...)}, nil
+}
+
+func anthropicHTTPStatus(err error) int {
+	var providerErr *Error
+	if errors.As(err, &providerErr) {
+		return providerErr.StatusCode
+	}
+	return 0
 }
 
 type Tokenizer struct {

--- a/ai/anthropic/model_test.go
+++ b/ai/anthropic/model_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/lace-ai/gai/ai"
+	"github.com/lace-ai/gai/internal/obstest"
 )
 
 func testModel(t *testing.T, handler http.HandlerFunc) *Model {
@@ -54,6 +55,7 @@ func array(t *testing.T, value any) []any {
 }
 
 func TestGenerateSendsAnthropicRequestAndMapsBlocksAndUsage(t *testing.T) {
+	recorder := obstest.Install(t)
 	m := testModel(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/messages" || r.Method != http.MethodPost {
 			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
@@ -80,6 +82,10 @@ func TestGenerateSendsAnthropicRequestAndMapsBlocksAndUsage(t *testing.T) {
 	}
 	if got.ToolCalls[0].ID != "toolu_1" || got.ToolCalls[0].Type != "function" || got.ToolCalls[0].Name != "search" || string(got.ToolCalls[0].Args) != `{"q":"x"}` {
 		t.Fatalf("unexpected tool call: %#v", got.ToolCalls[0])
+	}
+	attrs := obstest.Attributes(obstest.RequireGenerationSpans(t, recorder, 1)[0])
+	if attrs["gen_ai.provider.name"].AsString() != "anthropic" || attrs["gen_ai.usage.input_tokens"].AsInt64() != 15 || attrs["gai.gen_ai.response.tool_call_count"].AsInt64() != 1 {
+		t.Fatalf("generation attrs = %#v", attrs)
 	}
 }
 
@@ -286,6 +292,7 @@ func TestGenerateStreamMapsInterleavedBlocksAndToolJSON(t *testing.T) {
 }
 
 func TestGenerateStreamEmitsTerminalCompletionSnapshot(t *testing.T) {
+	recorder := obstest.Install(t)
 	m := testModel(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte("event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"id\":\"msg_1\",\"model\":\"claude-test\"}}\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":10,\"cache_creation_input_tokens\":2,\"cache_read_input_tokens\":3,\"output_tokens\":4,\"output_tokens_details\":{\"thinking_tokens\":1}}}\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"))
@@ -303,9 +310,14 @@ func TestGenerateStreamEmitsTerminalCompletionSnapshot(t *testing.T) {
 	if completion.Usage.InputTokens != 15 || completion.Usage.OutputTokens != 4 || completion.Usage.ReasoningTokens != 1 || completion.Usage.CachedTokens != 3 || completion.Usage.CacheCreationTokens != 2 || !json.Valid(completion.Raw) {
 		t.Fatalf("completion usage = %#v, raw = %q", completion.Usage, completion.Raw)
 	}
+	attrs := obstest.Attributes(obstest.RequireGenerationSpans(t, recorder, 1)[0])
+	if !attrs["gai.gen_ai.streaming"].AsBool() || attrs["gen_ai.usage.input_tokens"].AsInt64() != 15 {
+		t.Fatalf("generation attrs = %#v", attrs)
+	}
 }
 
 func TestGenerateStreamErrorAndCancellation(t *testing.T) {
+	recorder := obstest.Install(t)
 	m := testModel(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte("event: error\ndata: {\"type\":\"error\",\"error\":{\"type\":\"overloaded_error\",\"message\":\"busy\"}}\n\n"))
@@ -343,6 +355,12 @@ func TestGenerateStreamErrorAndCancellation(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("stream did not close after cancellation")
+	}
+	spans := obstest.RequireGenerationSpansEventually(t, recorder, 2, time.Second)
+	for _, span := range spans {
+		if span.Status().Code.String() != "Error" {
+			t.Fatalf("generation status = %s, want Error", span.Status().Code)
+		}
 	}
 }
 

--- a/ai/gemini/model.go
+++ b/ai/gemini/model.go
@@ -74,6 +74,8 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 		var streamErr error
 		var observation *ai.GenerationObservation
 		generationResult := ai.GenerationResult{}
+		completion := ai.Completion{Provider: "gemini"}
+		hasCompletion := false
 		defer close(out)
 		if gai.DebugContentEnabled(ctx, m.debug, gai.ContentKindPrompt) {
 			fields := map[string]any{"max_tokens": req.MaxTokens}
@@ -85,6 +87,15 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			})
 		}
 		defer func() {
+			if hasCompletion {
+				generationResult.ResponseModel = completion.Model
+				generationResult.RequestID = completion.RequestID
+				generationResult.FinishReason = completion.FinishReason
+				if completion.UsageReported {
+					usage := completion.Usage
+					generationResult.Usage = &usage
+				}
+			}
 			generationResult.Err = streamErr
 			observation.Finish(generationResult)
 		}()
@@ -93,7 +104,9 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			if ai.SendToken(ctx, out, token) {
 				return true
 			}
-			streamErr = ctx.Err()
+			if streamErr == nil {
+				streamErr = ctx.Err()
+			}
 			return false
 		}
 		if err := ai.ValidateModelRequest(m, req); err != nil {
@@ -136,8 +149,6 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 		generationCtx, startedObservation := ai.StartGenerationObservation(ctx, req, ai.GenerationConfig{Provider: "gemini", Model: m.name, Streaming: true})
 		observation = startedObservation
 		ctx = generationCtx
-		completion := ai.Completion{Provider: "gemini"}
-		hasCompletion := false
 		for resp, err := range client.Models.GenerateContentStream(generationCtx, m.name, contents, config) {
 			if err != nil {
 				streamErr = fmt.Errorf("error generating content stream: %w", err)

--- a/ai/gemini/model.go
+++ b/ai/gemini/model.go
@@ -3,6 +3,7 @@ package gemini
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -58,6 +59,18 @@ func geminiAdapterDescriptor(model string) ai.ModelDescriptor {
 		Tokenizer: ai.TokenizerDescriptor{Available: ai.FeatureSupportSupported, Fidelity: ai.TokenizerFidelityExact}}
 }
 
+func geminiHTTPStatus(err error) int {
+	var apiErr *genai.APIError
+	if errors.As(err, &apiErr) && apiErr != nil {
+		return apiErr.Code
+	}
+	var apiErrValue genai.APIError
+	if errors.As(err, &apiErrValue) {
+		return apiErrValue.Code
+	}
+	return 0
+}
+
 func (m *Model) Close() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -96,6 +109,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 					generationResult.Usage = &usage
 				}
 			}
+			generationResult.HTTPStatus = geminiHTTPStatus(streamErr)
 			generationResult.Err = streamErr
 			observation.Finish(generationResult)
 		}()
@@ -340,6 +354,7 @@ func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (response *ai.AI
 	ctx, observation := ai.StartGenerationObservation(ctx, req, ai.GenerationConfig{Provider: "gemini", Model: m.name})
 	generationResult := ai.GenerationResult{}
 	defer func() {
+		generationResult.HTTPStatus = geminiHTTPStatus(err)
 		generationResult.Err = err
 		observation.Finish(generationResult)
 	}()

--- a/ai/gemini/model.go
+++ b/ai/gemini/model.go
@@ -68,16 +68,13 @@ func (m *Model) Close() error {
 
 func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.Token {
 	out := make(chan ai.Token, 1)
-	prompt := req.Prompt
 
 	go func() {
-		ctx, span := gai.StartOperationSpan(ctx, geminiTracerName, "ai.gemini", "ai.operation", "model.generate_stream",
-			attribute.String("ai.provider", "gemini"),
-			attribute.String("ai.model", m.name),
-			attribute.Int("ai.max_tokens", req.MaxTokens),
-			attribute.Int("ai.prompt_length", len(prompt)),
-		)
+		ctx := ctx
 		var streamErr error
+		var observation *ai.GenerationObservation
+		generationResult := ai.GenerationResult{}
+		defer close(out)
 		if gai.DebugContentEnabled(ctx, m.debug, gai.ContentKindPrompt) {
 			fields := map[string]any{"max_tokens": req.MaxTokens}
 			gai.AddDebugContent(ctx, m.debug, fields, "prompt", gai.ContentKindPrompt, req.Prompt)
@@ -87,21 +84,21 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 				Fields: fields,
 			})
 		}
-		textTokenCount := 0
-		thoughtTokenCount := 0
-		toolCallCount := 0
 		defer func() {
-			span.SetAttributes(
-				attribute.Int("ai.text_token_count", textTokenCount),
-				attribute.Int("ai.thought_token_count", thoughtTokenCount),
-				attribute.Int("ai.tool_call_count", toolCallCount),
-			)
-			gai.EndSpan(span, streamErr)
+			generationResult.Err = streamErr
+			observation.Finish(generationResult)
 		}()
-		defer close(out)
+		emit := func(token ai.Token) bool {
+			observation.ObserveToken(token)
+			if ai.SendToken(ctx, out, token) {
+				return true
+			}
+			streamErr = ctx.Err()
+			return false
+		}
 		if err := ai.ValidateModelRequest(m, req); err != nil {
 			streamErr = err
-			ai.SendToken(ctx, out, ai.Token{Err: err, Type: ai.TokenTypeErr, Text: err.Error()})
+			emit(ai.Token{Err: err, Type: ai.TokenTypeErr, Text: err.Error()})
 			return
 		}
 
@@ -118,27 +115,30 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 					Err: err,
 				})
 			}
-			ai.SendToken(ctx, out, ai.Token{Err: err, Type: ai.TokenTypeErr, Text: err.Error()})
+			emit(ai.Token{Err: err, Type: ai.TokenTypeErr, Text: err.Error()})
 			return
 		}
 
 		config, err := buildGenerateContentConfig(req)
 		if err != nil {
 			streamErr = err
-			ai.SendToken(ctx, out, ai.Token{Err: err, Type: ai.TokenTypeErr, Text: err.Error()})
+			emit(ai.Token{Err: err, Type: ai.TokenTypeErr, Text: err.Error()})
 			return
 		}
 
 		contents, err := nativeContents(req)
 		if err != nil {
 			streamErr = err
-			ai.SendToken(ctx, out, ai.Token{Err: err, Type: ai.TokenTypeErr, Text: err.Error()})
+			emit(ai.Token{Err: err, Type: ai.TokenTypeErr, Text: err.Error()})
 			return
 		}
 
+		generationCtx, startedObservation := ai.StartGenerationObservation(ctx, req, ai.GenerationConfig{Provider: "gemini", Model: m.name, Streaming: true})
+		observation = startedObservation
+		ctx = generationCtx
 		completion := ai.Completion{Provider: "gemini"}
 		hasCompletion := false
-		for resp, err := range client.Models.GenerateContentStream(ctx, m.name, contents, config) {
+		for resp, err := range client.Models.GenerateContentStream(generationCtx, m.name, contents, config) {
 			if err != nil {
 				streamErr = fmt.Errorf("error generating content stream: %w", err)
 				if m.debug != nil {
@@ -151,7 +151,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 						Err: err,
 					})
 				}
-				ai.SendToken(ctx, out, ai.Token{Err: streamErr, Type: ai.TokenTypeErr, Text: streamErr.Error()})
+				emit(ai.Token{Err: streamErr, Type: ai.TokenTypeErr, Text: streamErr.Error()})
 				return
 			}
 
@@ -170,6 +170,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 				responseHasCompletion = true
 			}
 			if resp.UsageMetadata != nil {
+				completion.UsageReported = true
 				completion.Usage = ai.Usage{
 					InputTokens:     int(resp.UsageMetadata.PromptTokenCount),
 					OutputTokens:    int(resp.UsageMetadata.CandidatesTokenCount),
@@ -189,7 +190,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 				raw, marshalErr := json.Marshal(resp)
 				if marshalErr != nil {
 					streamErr = fmt.Errorf("encode Gemini completion metadata: %w", marshalErr)
-					ai.SendToken(ctx, out, ai.Token{Err: streamErr, Type: ai.TokenTypeErr, Text: streamErr.Error()})
+					emit(ai.Token{Err: streamErr, Type: ai.TokenTypeErr, Text: streamErr.Error()})
 					return
 				}
 				completion.Raw = append(completion.Raw[:0], raw...)
@@ -207,13 +208,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 				switch {
 				case part.Text != "":
 					token := buildTextToken(part)
-					switch token.Type {
-					case ai.TokenTypeThought:
-						thoughtTokenCount++
-					default:
-						textTokenCount++
-					}
-					if !ai.SendToken(ctx, out, token) {
+					if !emit(token) {
 						return
 					}
 				case part.FunctionCall != nil:
@@ -235,7 +230,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 								Err:    err,
 							})
 						}
-						ai.SendToken(ctx, out, ai.Token{Err: encodeErr, Type: ai.TokenTypeErr, Text: encodeErr.Error()})
+						emit(ai.Token{Err: encodeErr, Type: ai.TokenTypeErr, Text: encodeErr.Error()})
 						return
 					}
 					toolCall, err := mapFunctionCall(part.FunctionCall)
@@ -257,7 +252,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 								Err:    err,
 							})
 						}
-						ai.SendToken(ctx, out, ai.Token{Err: mapErr, Type: ai.TokenTypeErr, Text: mapErr.Error()})
+						emit(ai.Token{Err: mapErr, Type: ai.TokenTypeErr, Text: mapErr.Error()})
 						return
 					}
 					toolCall.ThoughtSignature = append([]byte(nil), part.ThoughtSignature...)
@@ -273,21 +268,20 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 							Fields: fields,
 						})
 					}
-					if !ai.SendToken(ctx, out, ai.Token{
+					if !emit(ai.Token{
 						Type:     ai.TokenTypeToolCall,
 						Data:     rawPart,
 						ToolCall: toolCall,
 					}) {
 						return
 					}
-					toolCallCount++
 				}
 			}
 		}
 		if hasCompletion {
 			snapshot := completion
 			snapshot.Raw = append(json.RawMessage(nil), completion.Raw...)
-			ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeCompletion, Completion: &snapshot})
+			emit(ai.Token{Type: ai.TokenTypeCompletion, Completion: &snapshot})
 		}
 	}()
 
@@ -295,14 +289,6 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 }
 
 func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (response *ai.AIResponse, err error) {
-	prompt := req.Prompt
-	ctx, span := gai.StartOperationSpan(ctx, geminiTracerName, "ai.gemini", "ai.operation", "model.generate",
-		attribute.String("ai.provider", "gemini"),
-		attribute.String("ai.model", m.name),
-		attribute.Int("ai.max_tokens", req.MaxTokens),
-		attribute.Int("ai.prompt_length", len(prompt)),
-	)
-	defer func() { gai.EndSpan(span, err) }()
 	if err := ai.ValidateModelRequest(m, req); err != nil {
 		return nil, err
 	}
@@ -340,6 +326,12 @@ func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (response *ai.AI
 	if err != nil {
 		return nil, err
 	}
+	ctx, observation := ai.StartGenerationObservation(ctx, req, ai.GenerationConfig{Provider: "gemini", Model: m.name})
+	generationResult := ai.GenerationResult{}
+	defer func() {
+		generationResult.Err = err
+		observation.Finish(generationResult)
+	}()
 	result, err := client.Models.GenerateContent(
 		ctx,
 		m.name,
@@ -370,12 +362,6 @@ func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (response *ai.AI
 	if result.UsageMetadata != nil {
 		reasoningTokens = int(result.UsageMetadata.ThoughtsTokenCount)
 	}
-	span.SetAttributes(
-		attribute.Int("ai.input_tokens", inputTokens),
-		attribute.Int("ai.output_tokens", outputTokens),
-		attribute.Int("ai.reasoning_tokens", reasoningTokens),
-	)
-
 	text, reasoning, toolCalls, err := mapGenerateContentResponse(result)
 	if err != nil {
 		return nil, err
@@ -394,6 +380,19 @@ func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (response *ai.AI
 		})
 	}
 	raw, _ := json.Marshal(result)
+	generationResult.ResponseModel = result.ModelVersion
+	generationResult.RequestID = result.ResponseID
+	generationResult.ToolCallCount = len(toolCalls)
+	if result.UsageMetadata != nil {
+		usage := ai.Usage{
+			InputTokens: inputTokens, OutputTokens: outputTokens, ReasoningTokens: reasoningTokens,
+			CachedTokens: int(result.UsageMetadata.CachedContentTokenCount), ToolUseTokens: int(result.UsageMetadata.ToolUsePromptTokenCount),
+		}
+		generationResult.Usage = &usage
+	}
+	if len(result.Candidates) > 0 && result.Candidates[0] != nil {
+		generationResult.FinishReason = string(result.Candidates[0].FinishReason)
+	}
 	return &ai.AIResponse{
 		Text:            text,
 		Reasoning:       reasoning,
@@ -402,6 +401,7 @@ func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (response *ai.AI
 		InputTokens:     inputTokens,
 		OutputTokens:    outputTokens,
 		ReasoningTokens: reasoningTokens,
+		FinishReason:    generationResult.FinishReason,
 	}, nil
 }
 

--- a/ai/gemini/model_test.go
+++ b/ai/gemini/model_test.go
@@ -78,6 +78,43 @@ func TestModelGenerateStreamEmitsCompletionForIdentityMetadata(t *testing.T) {
 	}
 }
 
+func TestModelGenerateStreamPreservesCompletionBeforeError(t *testing.T) {
+	recorder := obstest.Install(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"responseId\":\"resp_before_error\",\"modelVersion\":\"gemini-resolved\"}\n\n"))
+		_, _ = w.Write([]byte("data: {not-json}\n\n"))
+	}))
+	defer server.Close()
+
+	provider := New("test-api-key", nil)
+	provider.baseURL = server.URL
+	provider.httpClient = server.Client()
+	model, err := provider.Model("gemini-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var completionCount int
+	var streamError error
+	for token := range model.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+		if token.Type == ai.TokenTypeCompletion {
+			completionCount++
+		}
+		if token.Type == ai.TokenTypeErr {
+			streamError = token.Err
+		}
+	}
+	if streamError == nil || completionCount != 0 {
+		t.Fatalf("stream error = %v, completion count = %d", streamError, completionCount)
+	}
+	span := obstest.RequireGenerationSpans(t, recorder, 1)[0]
+	attrs := obstest.Attributes(span)
+	if span.Status().Code.String() != "Error" || attrs["gen_ai.response.id"].AsString() != "resp_before_error" || attrs["gen_ai.response.model"].AsString() != "gemini-resolved" {
+		t.Fatalf("generation status = %s, attrs = %#v", span.Status().Code, attrs)
+	}
+}
+
 func TestMapFunctionCall(t *testing.T) {
 	got, err := mapFunctionCall(&genai.FunctionCall{
 		ID:   "call_1",

--- a/ai/gemini/model_test.go
+++ b/ai/gemini/model_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/lace-ai/gai"
 	"github.com/lace-ai/gai/ai"
+	"github.com/lace-ai/gai/internal/obstest"
 	"google.golang.org/genai"
 )
 
@@ -31,6 +32,7 @@ func TestModelDescriptorRejectsUnknownReasoningEffortBeforeTransport(t *testing.
 }
 
 func TestModelGenerateStreamEmitsCompletionForIdentityMetadata(t *testing.T) {
+	recorder := obstest.Install(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			t.Fatalf("method = %s, want POST", r.Method)
@@ -69,6 +71,10 @@ func TestModelGenerateStreamEmitsCompletionForIdentityMetadata(t *testing.T) {
 	}
 	if raw.ResponseID != "resp_1" {
 		t.Fatalf("completion raw responseId = %q, want resp_1", raw.ResponseID)
+	}
+	attrs := obstest.Attributes(obstest.RequireGenerationSpans(t, recorder, 1)[0])
+	if attrs["gen_ai.provider.name"].AsString() != "gcp.gemini" || attrs["ai.provider"].AsString() != "gemini" || !attrs["gai.gen_ai.streaming"].AsBool() || attrs["gen_ai.response.id"].AsString() != "resp_1" {
+		t.Fatalf("generation attrs = %#v", attrs)
 	}
 }
 
@@ -147,6 +153,7 @@ func TestNativeContentsPreservesThoughtSignatureOnFunctionCall(t *testing.T) {
 }
 
 func TestGenerateEmitsDebugEventOnGenerationFailure(t *testing.T) {
+	recorder := obstest.Install(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, `{"error":{"message":"generation failed"}}`, http.StatusInternalServerError)
 	}))
@@ -167,12 +174,19 @@ func TestGenerateEmitsDebugEventOnGenerationFailure(t *testing.T) {
 	if err == nil {
 		t.Fatal("Generate error = nil, want API error")
 	}
+	found := false
 	for _, event := range events {
 		if event.Name == "gemini_generate_content_failed" && event.Err != nil {
-			return
+			found = true
 		}
 	}
-	t.Fatalf("gemini_generate_content_failed event not emitted: %#v", events)
+	if !found {
+		t.Fatalf("gemini_generate_content_failed event not emitted: %#v", events)
+	}
+	spans := obstest.RequireGenerationSpans(t, recorder, 1)
+	if spans[0].Status().Code.String() != "Error" {
+		t.Fatalf("generation status = %s", spans[0].Status().Code)
+	}
 }
 
 func TestMapFunctionCallEmptyName(t *testing.T) {

--- a/ai/gemini/model_test.go
+++ b/ai/gemini/model_test.go
@@ -192,7 +192,7 @@ func TestNativeContentsPreservesThoughtSignatureOnFunctionCall(t *testing.T) {
 func TestGenerateEmitsDebugEventOnGenerationFailure(t *testing.T) {
 	recorder := obstest.Install(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		http.Error(w, `{"error":{"message":"generation failed"}}`, http.StatusInternalServerError)
+		http.Error(w, `{"error":{"code":429,"message":"generation failed"}}`, http.StatusTooManyRequests)
 	}))
 	defer server.Close()
 
@@ -223,6 +223,41 @@ func TestGenerateEmitsDebugEventOnGenerationFailure(t *testing.T) {
 	spans := obstest.RequireGenerationSpans(t, recorder, 1)
 	if spans[0].Status().Code.String() != "Error" {
 		t.Fatalf("generation status = %s", spans[0].Status().Code)
+	}
+	attrs := obstest.Attributes(spans[0])
+	if attrs["http.response.status_code"].AsInt64() != http.StatusTooManyRequests {
+		t.Fatalf("HTTP status attribute = %d, want %d", attrs["http.response.status_code"].AsInt64(), http.StatusTooManyRequests)
+	}
+}
+
+func TestModelGenerateStreamRecordsAPIErrorStatus(t *testing.T) {
+	recorder := obstest.Install(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":{"code":429,"message":"rate limited"}}`, http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	provider := New("test-api-key", nil)
+	provider.httpClient = server.Client()
+	provider.baseURL = server.URL
+	model, err := provider.Model("gemini-test")
+	if err != nil {
+		t.Fatalf("Model error: %v", err)
+	}
+
+	var streamErr error
+	for token := range model.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+		if token.Type == ai.TokenTypeErr {
+			streamErr = token.Err
+		}
+	}
+	if streamErr == nil {
+		t.Fatal("stream error = nil, want API error")
+	}
+	span := obstest.RequireGenerationSpans(t, recorder, 1)[0]
+	attrs := obstest.Attributes(span)
+	if attrs["http.response.status_code"].AsInt64() != http.StatusTooManyRequests {
+		t.Fatalf("HTTP status attribute = %d, want %d", attrs["http.response.status_code"].AsInt64(), http.StatusTooManyRequests)
 	}
 }
 

--- a/ai/generation_observation.go
+++ b/ai/generation_observation.go
@@ -164,7 +164,12 @@ func mergeGenerationResults(stream, final GenerationResult) GenerationResult {
 	if final.Usage == nil {
 		final.Usage = stream.Usage
 	}
-	final.ToolCallCount += stream.ToolCallCount
+	// A caller-provided final count is authoritative. Streaming observations are
+	// the fallback so providers may summarize their final result without
+	// double-counting tool-call tokens already seen by ObserveToken.
+	if final.ToolCallCount == 0 {
+		final.ToolCallCount = stream.ToolCallCount
+	}
 	return final
 }
 

--- a/ai/generation_observation.go
+++ b/ai/generation_observation.go
@@ -1,0 +1,250 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/lace-ai/gai"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const generationTracerName = "github.com/lace-ai/gai/ai"
+
+// GenerationConfig identifies one provider model invocation.
+type GenerationConfig struct {
+	Provider  string
+	Model     string
+	Streaming bool
+}
+
+// GenerationResult contains provider metadata known when a generation ends.
+// Usage must be nil when the provider did not report usage. A non-nil Usage
+// records reported zero values as zero rather than treating them as missing.
+type GenerationResult struct {
+	ResponseModel string
+	RequestID     string
+	FinishReason  string
+	Usage         *Usage
+	ToolCallCount int
+	HTTPStatus    int
+	Err           error
+}
+
+// GenerationObservation owns the one semantic generation span associated with
+// one provider invocation. It is safe to finish more than once; only the first
+// call ends the span.
+type GenerationObservation struct {
+	span       trace.Span
+	startedAt  time.Time
+	firstOnce  sync.Once
+	finishOnce sync.Once
+	mu         sync.Mutex
+	stream     GenerationResult
+}
+
+// StartGenerationObservation starts a provider-neutral generation span. Call
+// it immediately before invoking the provider, after local validation and
+// request mapping have succeeded.
+func StartGenerationObservation(ctx context.Context, req AIRequest, config GenerationConfig) (context.Context, *GenerationObservation) {
+	startedAt := time.Now()
+	attrs := []attribute.KeyValue{
+		attribute.String("langfuse.observation.type", "generation"),
+		attribute.String("langfuse.observation.model.name", config.Model),
+		attribute.String("gen_ai.provider.name", semanticProviderName(config.Provider)),
+		attribute.String("gen_ai.request.model", config.Model),
+		attribute.Bool("gai.gen_ai.streaming", config.Streaming),
+		attribute.String("ai.provider", config.Provider),
+		attribute.String("ai.model", config.Model),
+		attribute.Int("ai.max_tokens", req.MaxTokens),
+		attribute.Int("ai.prompt_length", len(req.Prompt)),
+	}
+	if req.MaxTokens > 0 {
+		attrs = append(attrs, attribute.Int("gen_ai.request.max_tokens", req.MaxTokens))
+	}
+	if parameters := generationModelParameters(req); parameters != "" {
+		attrs = append(attrs, attribute.String("langfuse.observation.model.parameters", parameters))
+	}
+	ctx, span := gai.StartClientOperationSpan(ctx, generationTracerName, "chat "+config.Model, "gen_ai.operation.name", "chat", attrs...)
+	return ctx, &GenerationObservation{span: span, startedAt: startedAt}
+}
+
+func semanticProviderName(provider string) string {
+	switch provider {
+	case "gemini":
+		return "gcp.gemini"
+	case "mistral":
+		return "mistral_ai"
+	default:
+		return provider
+	}
+}
+
+// FirstOutput records when the first meaningful response text, reasoning, or
+// tool call arrived. Usage-only and identity-only chunks must not call it.
+func (o *GenerationObservation) FirstOutput() {
+	if o == nil {
+		return
+	}
+	o.firstOnce.Do(func() {
+		now := time.Now()
+		o.span.SetAttributes(
+			attribute.String("langfuse.observation.completion_start_time", now.UTC().Format(time.RFC3339Nano)),
+			attribute.Float64("gai.gen_ai.time_to_first_output_ms", float64(now.Sub(o.startedAt).Microseconds())/1000),
+		)
+		o.span.AddEvent("gen_ai.completion.start", trace.WithTimestamp(now))
+	})
+}
+
+// ObserveToken records normalized streaming metadata and first-output timing.
+func (o *GenerationObservation) ObserveToken(token Token) {
+	if o == nil {
+		return
+	}
+	switch token.Type {
+	case TokenTypeText, TokenTypeThought:
+		if token.Text != "" || len(token.Data) != 0 {
+			o.FirstOutput()
+		}
+	case TokenTypeToolCall:
+		o.FirstOutput()
+		o.mu.Lock()
+		o.stream.ToolCallCount++
+		o.mu.Unlock()
+	case TokenTypeCompletion:
+		if token.Completion == nil {
+			return
+		}
+		o.mu.Lock()
+		completion := token.Completion
+		if completion.Model != "" {
+			o.stream.ResponseModel = completion.Model
+		}
+		if completion.RequestID != "" {
+			o.stream.RequestID = completion.RequestID
+		}
+		if completion.FinishReason != "" {
+			o.stream.FinishReason = completion.FinishReason
+		}
+		if completion.UsageReported {
+			usage := completion.Usage
+			o.stream.Usage = &usage
+		}
+		o.mu.Unlock()
+	}
+}
+
+// Finish records final metadata and ends the generation span. It is idempotent.
+func (o *GenerationObservation) Finish(result GenerationResult) {
+	if o == nil {
+		return
+	}
+	o.finishOnce.Do(func() {
+		o.mu.Lock()
+		result = mergeGenerationResults(o.stream, result)
+		o.mu.Unlock()
+		o.span.SetAttributes(generationResultAttributes(result)...)
+		gai.EndSpan(o.span, result.Err)
+	})
+}
+
+func mergeGenerationResults(stream, final GenerationResult) GenerationResult {
+	if final.ResponseModel == "" {
+		final.ResponseModel = stream.ResponseModel
+	}
+	if final.RequestID == "" {
+		final.RequestID = stream.RequestID
+	}
+	if final.FinishReason == "" {
+		final.FinishReason = stream.FinishReason
+	}
+	if final.Usage == nil {
+		final.Usage = stream.Usage
+	}
+	final.ToolCallCount += stream.ToolCallCount
+	return final
+}
+
+func generationResultAttributes(result GenerationResult) []attribute.KeyValue {
+	attrs := []attribute.KeyValue{
+		attribute.Int("gai.gen_ai.response.tool_call_count", result.ToolCallCount),
+		attribute.Int("ai.tool_call_count", result.ToolCallCount),
+	}
+	if result.ResponseModel != "" {
+		attrs = append(attrs,
+			attribute.String("gen_ai.response.model", result.ResponseModel),
+			attribute.String("langfuse.observation.model.name", result.ResponseModel),
+		)
+	}
+	if result.RequestID != "" {
+		attrs = append(attrs, attribute.String("gen_ai.response.id", result.RequestID))
+	}
+	if result.FinishReason != "" {
+		attrs = append(attrs, attribute.StringSlice("gen_ai.response.finish_reasons", []string{result.FinishReason}))
+	}
+	if result.HTTPStatus > 0 {
+		attrs = append(attrs, attribute.Int("http.response.status_code", result.HTTPStatus))
+	}
+	if result.Err != nil {
+		attrs = append(attrs, attribute.String("error.type", fmt.Sprintf("%T", result.Err)))
+	}
+	if result.Usage == nil {
+		return attrs
+	}
+	usage := *result.Usage
+	attrs = append(attrs,
+		attribute.Int("gen_ai.usage.input_tokens", usage.InputTokens),
+		attribute.Int("gen_ai.usage.output_tokens", usage.OutputTokens),
+		attribute.Int("gen_ai.usage.total_tokens", usage.InputTokens+usage.OutputTokens),
+		attribute.Int("ai.input_tokens", usage.InputTokens),
+		attribute.Int("ai.output_tokens", usage.OutputTokens),
+	)
+	details := map[string]int{
+		"input": usage.InputTokens, "output": usage.OutputTokens,
+		"total": usage.InputTokens + usage.OutputTokens,
+	}
+	if usage.ReasoningTokens > 0 {
+		attrs = append(attrs,
+			attribute.Int("gen_ai.usage.reasoning.output_tokens", usage.ReasoningTokens),
+			attribute.Int("ai.reasoning_tokens", usage.ReasoningTokens),
+		)
+		details["reasoning"] = usage.ReasoningTokens
+	}
+	if usage.CachedTokens > 0 {
+		attrs = append(attrs, attribute.Int("gen_ai.usage.cache_read.input_tokens", usage.CachedTokens))
+		details["cached"] = usage.CachedTokens
+	}
+	if usage.CacheCreationTokens > 0 {
+		attrs = append(attrs, attribute.Int("gai.gen_ai.usage.cache_creation.input_tokens", usage.CacheCreationTokens))
+		details["cache_creation"] = usage.CacheCreationTokens
+	}
+	if usage.ToolUseTokens > 0 {
+		attrs = append(attrs, attribute.Int("gai.gen_ai.usage.tool.input_tokens", usage.ToolUseTokens))
+		details["tool_use"] = usage.ToolUseTokens
+	}
+	if raw, err := json.Marshal(details); err == nil {
+		attrs = append(attrs, attribute.String("langfuse.observation.usage_details", string(raw)))
+	}
+	return attrs
+}
+
+func generationModelParameters(req AIRequest) string {
+	parameters := make(map[string]any, 2)
+	if req.MaxTokens > 0 {
+		parameters["max_tokens"] = req.MaxTokens
+	}
+	if req.ResponseFormat.Type != "" {
+		parameters["response_format"] = string(req.ResponseFormat.Type)
+	}
+	if len(parameters) == 0 {
+		return ""
+	}
+	raw, err := json.Marshal(parameters)
+	if err != nil {
+		return ""
+	}
+	return string(raw)
+}

--- a/ai/generation_observation.go
+++ b/ai/generation_observation.go
@@ -50,7 +50,6 @@ type GenerationObservation struct {
 // it immediately before invoking the provider, after local validation and
 // request mapping have succeeded.
 func StartGenerationObservation(ctx context.Context, req AIRequest, config GenerationConfig) (context.Context, *GenerationObservation) {
-	startedAt := time.Now()
 	attrs := []attribute.KeyValue{
 		attribute.String("langfuse.observation.type", "generation"),
 		attribute.String("langfuse.observation.model.name", config.Model),
@@ -69,6 +68,7 @@ func StartGenerationObservation(ctx context.Context, req AIRequest, config Gener
 		attrs = append(attrs, attribute.String("langfuse.observation.model.parameters", parameters))
 	}
 	ctx, span := gai.StartClientOperationSpan(ctx, generationTracerName, "chat "+config.Model, "gen_ai.operation.name", "chat", attrs...)
+	startedAt := time.Now()
 	return ctx, &GenerationObservation{span: span, startedAt: startedAt}
 }
 

--- a/ai/generation_observation_test.go
+++ b/ai/generation_observation_test.go
@@ -101,6 +101,18 @@ func TestGenerationObservationDistinguishesMissingAndReportedZeroUsage(t *testin
 	assertIntAttribute(t, reportedAttrs, "gen_ai.usage.output_tokens", 0)
 }
 
+func TestGenerationObservationFinalToolCallCountTakesPrecedence(t *testing.T) {
+	recorder, restore := installGenerationSpanRecorder(t)
+	defer restore()
+
+	_, observation := StartGenerationObservation(context.Background(), AIRequest{}, GenerationConfig{Provider: "test", Model: "m", Streaming: true})
+	observation.ObserveToken(Token{Type: TokenTypeToolCall, ToolCall: &ToolCall{Name: "search"}})
+	observation.Finish(GenerationResult{ToolCallCount: 1})
+
+	attrs := spanAttributes(generationSpan(t, recorder.Ended()).Attributes())
+	assertIntAttribute(t, attrs, "gai.gen_ai.response.tool_call_count", 1)
+}
+
 func TestGenerationObservationCreatesOneParentedSpanPerAttempt(t *testing.T) {
 	recorder, restore := installGenerationSpanRecorder(t)
 	defer restore()

--- a/ai/generation_observation_test.go
+++ b/ai/generation_observation_test.go
@@ -1,0 +1,193 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func TestGenerationObservationRecordsSemanticContract(t *testing.T) {
+	recorder, restore := installGenerationSpanRecorder(t)
+	defer restore()
+
+	ctx, parent := otel.Tracer("test").Start(context.Background(), "parent")
+	ctx, observation := StartGenerationObservation(ctx, AIRequest{
+		Prompt: "private prompt", MaxTokens: 42,
+		ResponseFormat: ResponseFormat{Type: ResponseFormatJSONSchema},
+	}, GenerationConfig{Provider: "test-provider", Model: "requested-model", Streaming: true})
+	observation.ObserveToken(Token{Type: TokenTypeText, Text: "private completion"})
+	observation.ObserveToken(Token{Type: TokenTypeToolCall, ToolCall: &ToolCall{Name: "search"}})
+	observation.ObserveToken(Token{Type: TokenTypeCompletion, Completion: &Completion{
+		Model: "resolved-model", RequestID: "request-1", FinishReason: "tool_calls",
+		UsageReported: true,
+		Usage:         Usage{InputTokens: 11, OutputTokens: 7, ReasoningTokens: 3, CachedTokens: 2},
+	}})
+	observation.Finish(GenerationResult{HTTPStatus: 200})
+	observation.Finish(GenerationResult{Err: errors.New("must be ignored")})
+	parent.End()
+
+	span := generationSpan(t, recorder.Ended())
+	if span.Name() != "chat requested-model" {
+		t.Fatalf("span name = %q, want %q", span.Name(), "chat requested-model")
+	}
+	attrs := spanAttributes(span.Attributes())
+	assertStringAttribute(t, attrs, "langfuse.observation.type", "generation")
+	assertStringAttribute(t, attrs, "langfuse.observation.model.name", "resolved-model")
+	assertStringAttribute(t, attrs, "gen_ai.provider.name", "test-provider")
+	assertStringAttribute(t, attrs, "gen_ai.request.model", "requested-model")
+	assertStringAttribute(t, attrs, "gen_ai.response.id", "request-1")
+	assertIntAttribute(t, attrs, "gen_ai.usage.input_tokens", 11)
+	assertIntAttribute(t, attrs, "gen_ai.usage.output_tokens", 7)
+	assertIntAttribute(t, attrs, "gen_ai.usage.total_tokens", 18)
+	assertIntAttribute(t, attrs, "gai.gen_ai.response.tool_call_count", 1)
+	assertIntAttribute(t, attrs, "http.response.status_code", 200)
+	if got := attrs["gen_ai.response.finish_reasons"].AsStringSlice(); len(got) != 1 || got[0] != "tool_calls" {
+		t.Fatalf("finish reasons = %v", got)
+	}
+	if value := attrs["langfuse.observation.completion_start_time"].AsString(); value == "" {
+		t.Fatal("completion start time missing")
+	} else if _, err := time.Parse(time.RFC3339Nano, value); err != nil {
+		t.Fatalf("completion start time %q: %v", value, err)
+	}
+	if len(span.Events()) != 1 || span.Events()[0].Name != "gen_ai.completion.start" {
+		t.Fatalf("completion events = %#v", span.Events())
+	}
+	if span.Parent().SpanID() != parent.SpanContext().SpanID() {
+		t.Fatalf("parent span ID = %s, want %s", span.Parent().SpanID(), parent.SpanContext().SpanID())
+	}
+	if span.SpanKind() != trace.SpanKindClient {
+		t.Fatalf("span kind = %s, want client", span.SpanKind())
+	}
+	for key, value := range attrs {
+		if strings.Contains(value.Emit(), "private prompt") || strings.Contains(value.Emit(), "private completion") {
+			t.Fatalf("content leaked through %s", key)
+		}
+	}
+}
+
+func TestGenerationObservationDistinguishesMissingAndReportedZeroUsage(t *testing.T) {
+	recorder, restore := installGenerationSpanRecorder(t)
+	defer restore()
+
+	_, missing := StartGenerationObservation(context.Background(), AIRequest{}, GenerationConfig{Provider: "test", Model: "m"})
+	missing.Finish(GenerationResult{})
+	zero := Usage{}
+	_, reported := StartGenerationObservation(context.Background(), AIRequest{}, GenerationConfig{Provider: "test", Model: "m"})
+	reported.Finish(GenerationResult{Usage: &zero})
+
+	var spans []sdktrace.ReadOnlySpan
+	for _, span := range recorder.Ended() {
+		if isGenerationSpan(span) {
+			spans = append(spans, span)
+		}
+	}
+	if len(spans) != 2 {
+		t.Fatalf("generation spans = %d, want 2", len(spans))
+	}
+	missingAttrs := spanAttributes(spans[0].Attributes())
+	if _, ok := missingAttrs["gen_ai.usage.input_tokens"]; ok {
+		t.Fatal("missing usage emitted input tokens")
+	}
+	reportedAttrs := spanAttributes(spans[1].Attributes())
+	assertIntAttribute(t, reportedAttrs, "gen_ai.usage.input_tokens", 0)
+	assertIntAttribute(t, reportedAttrs, "gen_ai.usage.output_tokens", 0)
+}
+
+func TestGenerationObservationCreatesOneParentedSpanPerAttempt(t *testing.T) {
+	recorder, restore := installGenerationSpanRecorder(t)
+	defer restore()
+
+	ctx, parent := otel.Tracer("test").Start(context.Background(), "loop.attempts")
+	for range 2 {
+		_, observation := StartGenerationObservation(ctx, AIRequest{}, GenerationConfig{Provider: "test", Model: "m"})
+		observation.Finish(GenerationResult{})
+	}
+	parent.End()
+
+	var generations []sdktrace.ReadOnlySpan
+	for _, span := range recorder.Ended() {
+		if isGenerationSpan(span) {
+			generations = append(generations, span)
+		}
+	}
+	if len(generations) != 2 {
+		t.Fatalf("generation spans = %d, want one per attempt", len(generations))
+	}
+	if generations[0].SpanContext().SpanID() == generations[1].SpanContext().SpanID() {
+		t.Fatal("attempt spans reused a span ID")
+	}
+	for _, span := range generations {
+		if span.Parent().SpanID() != parent.SpanContext().SpanID() {
+			t.Fatalf("attempt parent = %s, want %s", span.Parent().SpanID(), parent.SpanContext().SpanID())
+		}
+	}
+}
+
+func installGenerationSpanRecorder(t *testing.T) (*tracetest.SpanRecorder, func()) {
+	t.Helper()
+	previous := otel.GetTracerProvider()
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(provider)
+	return recorder, func() {
+		_ = provider.Shutdown(context.Background())
+		otel.SetTracerProvider(previous)
+	}
+}
+
+func generationSpan(t *testing.T, spans []sdktrace.ReadOnlySpan) sdktrace.ReadOnlySpan {
+	t.Helper()
+	var found sdktrace.ReadOnlySpan
+	for _, span := range spans {
+		if !isGenerationSpan(span) {
+			continue
+		}
+		if found != nil {
+			t.Fatal("duplicate generation span")
+		}
+		found = span
+	}
+	if found == nil {
+		t.Fatal("generation span missing")
+	}
+	return found
+}
+
+func isGenerationSpan(span sdktrace.ReadOnlySpan) bool {
+	for _, attr := range span.Attributes() {
+		if string(attr.Key) == "langfuse.observation.type" && attr.Value.AsString() == "generation" {
+			return true
+		}
+	}
+	return false
+}
+
+func spanAttributes(attrs []attribute.KeyValue) map[string]attribute.Value {
+	result := make(map[string]attribute.Value, len(attrs))
+	for _, attr := range attrs {
+		result[string(attr.Key)] = attr.Value
+	}
+	return result
+}
+
+func assertStringAttribute(t *testing.T, attrs map[string]attribute.Value, key, want string) {
+	t.Helper()
+	if got := attrs[key].AsString(); got != want {
+		t.Fatalf("%s = %q, want %q", key, got, want)
+	}
+}
+
+func assertIntAttribute(t *testing.T, attrs map[string]attribute.Value, key string, want int64) {
+	t.Helper()
+	if got := attrs[key].AsInt64(); got != want {
+		t.Fatalf("%s = %d, want %d", key, got, want)
+	}
+}

--- a/ai/generation_observation_test.go
+++ b/ai/generation_observation_test.go
@@ -73,6 +73,21 @@ func TestGenerationObservationRecordsSemanticContract(t *testing.T) {
 	}
 }
 
+func TestGenerationObservationTimingBaselineDoesNotPredateSpan(t *testing.T) {
+	recorder, restore := installGenerationSpanRecorder(t)
+	defer restore()
+
+	_, observation := StartGenerationObservation(context.Background(), AIRequest{}, GenerationConfig{Provider: "test", Model: "m"})
+	started := recorder.Started()
+	if len(started) != 1 {
+		t.Fatalf("started spans = %d, want 1", len(started))
+	}
+	if observation.startedAt.Before(started[0].StartTime()) {
+		t.Fatalf("timing baseline %s predates span start %s", observation.startedAt, started[0].StartTime())
+	}
+	observation.Finish(GenerationResult{})
+}
+
 func TestGenerationObservationDistinguishesMissingAndReportedZeroUsage(t *testing.T) {
 	recorder, restore := installGenerationSpanRecorder(t)
 	defer restore()

--- a/ai/mistral/model.go
+++ b/ai/mistral/model.go
@@ -529,7 +529,9 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			if ai.SendToken(ctx, raw, token) {
 				return true
 			}
-			streamErr = ctx.Err()
+			if streamErr == nil {
+				streamErr = ctx.Err()
+			}
 			return false
 		}
 		if err := ai.ValidateModelRequest(m, req); err != nil {
@@ -637,13 +639,13 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 						Err: readErr,
 					})
 				}
+				streamErr = fmt.Errorf("mistral chat stream failed (status %d): %w", res.StatusCode, readErr)
 				if !emit(ai.Token{
-					Err:  fmt.Errorf("mistral chat stream failed (status %d): %w", res.StatusCode, readErr),
+					Err:  streamErr,
 					Type: ai.TokenTypeErr,
 				}) {
 					return
 				}
-				streamErr = readErr
 				return
 			}
 			if m.debug != nil {
@@ -686,6 +688,16 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			hasCompletion = false
 			return nil
 		}
+		defer func() {
+			previousErr := streamErr
+			if emitErr := emitCompletion(); emitErr != nil {
+				if previousErr != nil {
+					streamErr = previousErr
+				} else {
+					streamErr = emitErr
+				}
+			}
+		}()
 
 		flushEvent := func() error {
 			event := strings.TrimSpace(eventData.String())

--- a/ai/mistral/model.go
+++ b/ai/mistral/model.go
@@ -117,6 +117,8 @@ type chatResponseJSONSchema struct {
 }
 
 type chatCompletionResponse struct {
+	ID      string `json:"id"`
+	Model   string `json:"model"`
 	Choices []struct {
 		Message struct {
 			Content   string          `json:"content"`
@@ -124,7 +126,7 @@ type chatCompletionResponse struct {
 		} `json:"message"`
 		FinishReason string `json:"finish_reason"`
 	} `json:"choices"`
-	Usage struct {
+	Usage *struct {
 		PromptTokens     int `json:"prompt_tokens"`
 		CompletionTokens int `json:"completion_tokens"`
 	} `json:"usage"`
@@ -369,6 +371,9 @@ func (t *Tokenizer) CountTokens(ctx context.Context, text string) (tokens int, e
 	if err := json.Unmarshal(resBody, &parsed); err != nil {
 		return 0, err
 	}
+	if parsed.Usage == nil {
+		return 0, nil
+	}
 	return parsed.Usage.PromptTokens, nil
 }
 
@@ -498,17 +503,14 @@ func (a *mistralToolCallAccumulator) ready(final bool) []ai.ToolCall {
 }
 
 func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.Token {
-	prompt := req.Prompt
-	ctx, span := gai.StartOperationSpan(ctx, mistralTracerName, "ai.mistral", "ai.operation", "model.generate_stream",
-		attribute.String("ai.provider", "mistral"),
-		attribute.String("ai.model", m.name),
-		attribute.Int("ai.max_tokens", req.MaxTokens),
-		attribute.Int("ai.prompt_length", len(prompt)),
-	)
 	raw := make(chan ai.Token, 1)
 
 	go func() {
+		ctx := ctx
 		var streamErr error
+		var observation *ai.GenerationObservation
+		generationResult := ai.GenerationResult{}
+		defer close(raw)
 		if gai.DebugContentEnabled(ctx, m.debug, gai.ContentKindPrompt) {
 			fields := map[string]any{"max_tokens": req.MaxTokens}
 			gai.AddDebugContent(ctx, m.debug, fields, "prompt", gai.ContentKindPrompt, req.Prompt)
@@ -518,17 +520,12 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 				Fields: fields,
 			})
 		}
-		textTokenCount := 0
-		toolCallCount := 0
 		defer func() {
-			span.SetAttributes(
-				attribute.Int("ai.text_token_count", textTokenCount),
-				attribute.Int("ai.tool_call_count", toolCallCount),
-			)
-			gai.EndSpan(span, streamErr)
+			generationResult.Err = streamErr
+			observation.Finish(generationResult)
 		}()
-		defer close(raw)
 		emit := func(token ai.Token) bool {
+			observation.ObserveToken(token)
 			if ai.SendToken(ctx, raw, token) {
 				return true
 			}
@@ -599,6 +596,10 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 		httpReq.Header.Set("Authorization", "Bearer "+m.client.apiKey)
 		httpReq.Header.Set("Content-Type", "application/json")
 		httpReq.Header.Set("Accept", "text/event-stream")
+		generationCtx, startedObservation := ai.StartGenerationObservation(ctx, req, ai.GenerationConfig{Provider: "mistral", Model: m.name, Streaming: true})
+		observation = startedObservation
+		ctx = generationCtx
+		httpReq = httpReq.WithContext(generationCtx)
 
 		res, err := m.client.httpClient.Do(httpReq)
 		if err != nil {
@@ -619,7 +620,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			return
 		}
 		defer res.Body.Close()
-		span.SetAttributes(attribute.Int("http.response.status_code", res.StatusCode))
+		generationResult.HTTPStatus = res.StatusCode
 
 		if res.StatusCode >= http.StatusMultipleChoices {
 			const maxResponseBody = 1 << 20 // 1MB
@@ -721,6 +722,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 				hasCompletion = true
 			}
 			if chunk.Usage != nil {
+				completion.UsageReported = true
 				completion.Usage = ai.Usage{InputTokens: chunk.Usage.PromptTokens, OutputTokens: chunk.Usage.CompletionTokens}
 				hasCompletion = true
 			}
@@ -746,7 +748,6 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 				if !emit(ai.Token{Type: ai.TokenTypeText, Text: text, Data: []byte(text)}) {
 					return ctx.Err()
 				}
-				textTokenCount++
 			}
 
 			finalToolCalls := chunk.Choices[0].FinishReason == "tool_calls"
@@ -787,7 +788,6 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 					}) {
 						return ctx.Err()
 					}
-					toolCallCount++
 				}
 			}
 
@@ -917,14 +917,6 @@ func intPtr(v int) *int {
 }
 
 func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (response *ai.AIResponse, err error) {
-	prompt := req.Prompt
-	ctx, span := gai.StartOperationSpan(ctx, mistralTracerName, "ai.mistral", "ai.operation", "model.generate",
-		attribute.String("ai.provider", "mistral"),
-		attribute.String("ai.model", m.name),
-		attribute.Int("ai.max_tokens", req.MaxTokens),
-		attribute.Int("ai.prompt_length", len(prompt)),
-	)
-	defer func() { gai.EndSpan(span, err) }()
 	if err := ai.ValidateModelRequest(m, req); err != nil {
 		return nil, err
 	}
@@ -959,12 +951,20 @@ func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (response *ai.AI
 	}
 	httpReq.Header.Set("Authorization", "Bearer "+m.client.apiKey)
 	httpReq.Header.Set("Content-Type", "application/json")
+	ctx, observation := ai.StartGenerationObservation(ctx, req, ai.GenerationConfig{Provider: "mistral", Model: m.name})
+	httpReq = httpReq.WithContext(ctx)
+	generationResult := ai.GenerationResult{}
+	defer func() {
+		generationResult.Err = err
+		observation.Finish(generationResult)
+	}()
 
 	res, err := m.client.httpClient.Do(httpReq)
 	if err != nil {
 		return nil, err
 	}
 	defer res.Body.Close()
+	generationResult.HTTPStatus = res.StatusCode
 
 	const maxResponseBody = 1 << 20 // 10MB
 	resBody, err := io.ReadAll(io.LimitReader(res.Body, maxResponseBody))
@@ -973,10 +973,8 @@ func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (response *ai.AI
 	}
 
 	if res.StatusCode >= http.StatusMultipleChoices {
-		span.SetAttributes(attribute.Int("http.response.status_code", res.StatusCode))
 		return nil, newHTTPError("chat completion", res.StatusCode, resBody)
 	}
-	span.SetAttributes(attribute.Int("http.response.status_code", res.StatusCode))
 
 	var parsed chatCompletionResponse
 	if err := json.Unmarshal(resBody, &parsed); err != nil {
@@ -989,14 +987,19 @@ func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (response *ai.AI
 	if err != nil {
 		return nil, err
 	}
-	span.SetAttributes(
-		attribute.Int("ai.input_tokens", parsed.Usage.PromptTokens),
-		attribute.Int("ai.output_tokens", parsed.Usage.CompletionTokens),
-	)
+	usage := ai.Usage{}
+	if parsed.Usage != nil {
+		usage = ai.Usage{InputTokens: parsed.Usage.PromptTokens, OutputTokens: parsed.Usage.CompletionTokens}
+		generationResult.Usage = &usage
+	}
+	generationResult.ResponseModel = parsed.Model
+	generationResult.RequestID = parsed.ID
+	generationResult.FinishReason = parsed.Choices[0].FinishReason
+	generationResult.ToolCallCount = len(toolCalls)
 	if m.debug != nil {
 		fields := map[string]any{
-			"input_tokens":  parsed.Usage.PromptTokens,
-			"output_tokens": parsed.Usage.CompletionTokens,
+			"input_tokens":  usage.InputTokens,
+			"output_tokens": usage.OutputTokens,
 		}
 		if _, hasPolicy := gai.ContentCapturePolicyFromContext(ctx); !hasPolicy && m.debug.IncludeSensitiveData() {
 			fields["response"] = parsed
@@ -1014,8 +1017,8 @@ func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (response *ai.AI
 		ToolCalls:    toolCalls,
 		Raw:          append([]byte(nil), resBody...),
 		FinishReason: parsed.Choices[0].FinishReason,
-		InputTokens:  parsed.Usage.PromptTokens,
-		OutputTokens: parsed.Usage.CompletionTokens,
+		InputTokens:  usage.InputTokens,
+		OutputTokens: usage.OutputTokens,
 	}, nil
 }
 

--- a/ai/mistral/model_test.go
+++ b/ai/mistral/model_test.go
@@ -582,6 +582,69 @@ func TestModelGenerateStreamEmitsCompletionForIdentityMetadata(t *testing.T) {
 	}
 }
 
+func TestModelGenerateStreamEmitsCompletionOnCleanEOFWithoutDone(t *testing.T) {
+	recorder := obstest.Install(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: {\"id\":\"cmpl_eof\",\"model\":\"mistral-eof\",\"choices\":[],\"usage\":{\"prompt_tokens\":9,\"completion_tokens\":4}}\n\n")
+	}))
+	defer ts.Close()
+	p := New("test-key", nil)
+	p.baseURL = ts.URL
+	m, err := p.Model(MistralSmallLatest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var completions []*ai.Completion
+	for token := range m.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+		if token.Type == ai.TokenTypeCompletion {
+			completions = append(completions, token.Completion)
+		}
+	}
+	if len(completions) != 1 || completions[0] == nil || completions[0].RequestID != "cmpl_eof" || completions[0].Usage.InputTokens != 9 {
+		t.Fatalf("completions = %#v", completions)
+	}
+	attrs := obstest.Attributes(obstest.RequireGenerationSpans(t, recorder, 1)[0])
+	if attrs["gen_ai.response.id"].AsString() != "cmpl_eof" || attrs["gen_ai.usage.output_tokens"].AsInt64() != 4 {
+		t.Fatalf("generation attrs = %#v", attrs)
+	}
+}
+
+func TestModelGenerateStreamPreservesCompletionOnMalformedEvent(t *testing.T) {
+	recorder := obstest.Install(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprint(w, "data: {\"id\":\"cmpl_error\",\"model\":\"mistral-error\",\"choices\":[],\"usage\":{\"prompt_tokens\":6,\"completion_tokens\":2}}\n\ndata: {not-json}\n\n")
+	}))
+	defer ts.Close()
+	p := New("test-key", nil)
+	p.baseURL = ts.URL
+	m, err := p.Model(MistralSmallLatest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var completion *ai.Completion
+	var streamError error
+	for token := range m.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+		switch token.Type {
+		case ai.TokenTypeCompletion:
+			completion = token.Completion
+		case ai.TokenTypeErr:
+			streamError = token.Err
+		}
+	}
+	if streamError == nil || completion == nil || completion.RequestID != "cmpl_error" {
+		t.Fatalf("stream error = %v, completion = %#v", streamError, completion)
+	}
+	span := obstest.RequireGenerationSpans(t, recorder, 1)[0]
+	attrs := obstest.Attributes(span)
+	if span.Status().Code.String() != "Error" || attrs["gen_ai.response.id"].AsString() != "cmpl_error" || attrs["gen_ai.usage.input_tokens"].AsInt64() != 6 {
+		t.Fatalf("generation status = %s, attrs = %#v", span.Status().Code, attrs)
+	}
+}
+
 func TestModelGenerateStreamToolCall(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")

--- a/ai/mistral/model_test.go
+++ b/ai/mistral/model_test.go
@@ -12,9 +12,11 @@ import (
 
 	"github.com/lace-ai/gai"
 	"github.com/lace-ai/gai/ai"
+	"github.com/lace-ai/gai/internal/obstest"
 )
 
 func TestModelGenerate(t *testing.T) {
+	recorder := obstest.Install(t)
 	var gotAuth string
 	var gotReq chatCompletionRequest
 
@@ -76,6 +78,10 @@ func TestModelGenerate(t *testing.T) {
 	}
 	if res.InputTokens != 11 || res.OutputTokens != 7 {
 		t.Fatalf("unexpected usage mapping: %+v", res)
+	}
+	attrs := obstest.Attributes(obstest.RequireGenerationSpans(t, recorder, 1)[0])
+	if attrs["gen_ai.provider.name"].AsString() != "mistral_ai" || attrs["ai.provider"].AsString() != "mistral" || attrs["gai.gen_ai.streaming"].AsBool() {
+		t.Fatalf("generation attrs = %#v", attrs)
 	}
 }
 
@@ -514,6 +520,7 @@ func TestModelGenerateStream(t *testing.T) {
 }
 
 func TestModelGenerateStreamEmitsTerminalCompletion(t *testing.T) {
+	recorder := obstest.Install(t)
 	var gotReq chatCompletionRequest
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
@@ -541,6 +548,10 @@ func TestModelGenerateStreamEmitsTerminalCompletion(t *testing.T) {
 	}
 	if completion == nil || completion.Provider != "mistral" || completion.RequestID != "cmpl_1" || completion.Model != "mistral-test" || completion.FinishReason != "stop" || completion.Usage.InputTokens != 7 || completion.Usage.OutputTokens != 3 || !json.Valid(completion.Raw) {
 		t.Fatalf("completion = %#v", completion)
+	}
+	attrs := obstest.Attributes(obstest.RequireGenerationSpans(t, recorder, 1)[0])
+	if !attrs["gai.gen_ai.streaming"].AsBool() || attrs["gen_ai.usage.input_tokens"].AsInt64() != 7 {
+		t.Fatalf("generation attrs = %#v", attrs)
 	}
 }
 

--- a/ai/openai/model.go
+++ b/ai/openai/model.go
@@ -3,6 +3,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -40,7 +41,7 @@ func (m *Model) Descriptor() ai.ModelDescriptor {
 	return openAIDescriptor(m.name)
 }
 
-func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (*ai.AIResponse, error) {
+func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (result *ai.AIResponse, err error) {
 	if err := ai.ValidateModelRequest(m, req); err != nil {
 		return nil, err
 	}
@@ -54,20 +55,37 @@ func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (*ai.AIResponse,
 	if err != nil {
 		return nil, err
 	}
+	ctx, observation := ai.StartGenerationObservation(ctx, req, ai.GenerationConfig{Provider: "openai", Model: m.name})
+	generationResult := ai.GenerationResult{}
+	defer func() {
+		generationResult.Err = err
+		generationResult.HTTPStatus = openAIHTTPStatus(err)
+		observation.Finish(generationResult)
+	}()
 	response, err := m.client(false).Chat.Completions.New(ctx, params)
 	if err != nil {
 		return nil, err
 	}
-	result := &ai.AIResponse{
+	result = &ai.AIResponse{
 		Raw:             json.RawMessage(response.RawJSON()),
 		InputTokens:     int(response.Usage.PromptTokens),
 		OutputTokens:    int(response.Usage.CompletionTokens),
 		ReasoningTokens: int(response.Usage.CompletionTokensDetails.ReasoningTokens),
 	}
+	generationResult.ResponseModel = response.Model
+	generationResult.RequestID = response.ID
+	if response.JSON.Usage.Valid() {
+		usage := ai.Usage{
+			InputTokens: result.InputTokens, OutputTokens: result.OutputTokens,
+			ReasoningTokens: result.ReasoningTokens, CachedTokens: int(response.Usage.PromptTokensDetails.CachedTokens),
+		}
+		generationResult.Usage = &usage
+	}
 	if len(response.Choices) == 0 {
 		return result, nil
 	}
 	message := response.Choices[0].Message
+	generationResult.FinishReason = response.Choices[0].FinishReason
 	result.Text = message.Content
 	for _, call := range message.ToolCalls {
 		args := json.RawMessage(strings.TrimSpace(call.Function.Arguments))
@@ -81,6 +99,7 @@ func (m *Model) Generate(ctx context.Context, req ai.AIRequest) (*ai.AIResponse,
 			ID: call.ID, Type: "function", Name: call.Function.Name, Args: args,
 		})
 	}
+	generationResult.ToolCallCount = len(result.ToolCalls)
 	return result, nil
 }
 
@@ -105,6 +124,25 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
 			return
 		}
+		ctx, observation := ai.StartGenerationObservation(ctx, req, ai.GenerationConfig{Provider: "openai", Model: m.name, Streaming: true})
+		var streamErr error
+		generationResult := ai.GenerationResult{}
+		defer func() {
+			generationResult.Err = streamErr
+			generationResult.HTTPStatus = openAIHTTPStatus(streamErr)
+			observation.Finish(generationResult)
+		}()
+		emit := func(token ai.Token) bool {
+			if token.Type == ai.TokenTypeErr && token.Err != nil {
+				streamErr = token.Err
+			}
+			observation.ObserveToken(token)
+			if ai.SendToken(ctx, out, token) {
+				return true
+			}
+			streamErr = ctx.Err()
+			return false
+		}
 		stream := m.client(true).Chat.Completions.NewStreaming(ctx, params)
 		defer func() {
 			if err := stream.Close(); err != nil && m.provider.debug != nil {
@@ -117,6 +155,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 		}()
 		calls := map[int64]*streamToolCall{}
 		completion := ai.Completion{Provider: "openai"}
+		defer func() { mergeOpenAICompletionResult(&generationResult, completion) }()
 		for stream.Next() {
 			chunk := stream.Current()
 			if chunk.ID != "" {
@@ -127,6 +166,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			}
 			if len(chunk.Choices) == 0 {
 				if chunk.JSON.Usage.Valid() {
+					completion.UsageReported = true
 					completion.Usage = ai.Usage{
 						InputTokens:     int(chunk.Usage.PromptTokens),
 						OutputTokens:    int(chunk.Usage.CompletionTokens),
@@ -136,7 +176,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 					completion.Raw = append(completion.Raw[:0], []byte(chunk.RawJSON())...)
 					snapshot := completion
 					snapshot.Raw = append(json.RawMessage(nil), completion.Raw...)
-					if !ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeCompletion, Completion: &snapshot}) {
+					if !emit(ai.Token{Type: ai.TokenTypeCompletion, Completion: &snapshot}) {
 						return
 					}
 				}
@@ -147,7 +187,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 				completion.FinishReason = string(choice.FinishReason)
 			}
 			if text := choice.Delta.Content; text != "" {
-				if !ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeText, Data: []byte(text), Text: text}) {
+				if !emit(ai.Token{Type: ai.TokenTypeText, Data: []byte(text), Text: text}) {
 					return
 				}
 			}
@@ -163,18 +203,43 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 				call.arguments.WriteString(delta.Function.Arguments)
 			}
 			if choice.FinishReason == "tool_calls" {
-				if !sendStreamToolCalls(ctx, out, calls) {
+				if !sendStreamToolCalls(emit, calls) {
 					return
 				}
 			}
 		}
 		if err := stream.Err(); err != nil {
-			ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
+			streamErr = err
+			emit(ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
 			return
 		}
-		sendStreamToolCalls(ctx, out, calls)
+		sendStreamToolCalls(emit, calls)
 	}()
 	return out
+}
+
+func mergeOpenAICompletionResult(result *ai.GenerationResult, completion ai.Completion) {
+	if completion.Model != "" {
+		result.ResponseModel = completion.Model
+	}
+	if completion.RequestID != "" {
+		result.RequestID = completion.RequestID
+	}
+	if completion.FinishReason != "" {
+		result.FinishReason = completion.FinishReason
+	}
+	if completion.UsageReported {
+		usage := completion.Usage
+		result.Usage = &usage
+	}
+}
+
+func openAIHTTPStatus(err error) int {
+	var apiErr *sdk.Error
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode
+	}
+	return 0
 }
 
 type streamToolCall struct {
@@ -183,7 +248,7 @@ type streamToolCall struct {
 	emitted             bool
 }
 
-func sendStreamToolCalls(ctx context.Context, out chan<- ai.Token, calls map[int64]*streamToolCall) bool {
+func sendStreamToolCalls(emit func(ai.Token) bool, calls map[int64]*streamToolCall) bool {
 	indices := make([]int64, 0, len(calls))
 	for index := range calls {
 		indices = append(indices, index)
@@ -202,10 +267,11 @@ func sendStreamToolCalls(ctx context.Context, out chan<- ai.Token, calls map[int
 		args := call.arguments.String()
 		if !json.Valid([]byte(args)) {
 			err := fmt.Errorf("invalid JSON arguments for tool %q", name)
-			return ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
+			emit(ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
+			return false
 		}
 		toolCall := &ai.ToolCall{ID: call.id.String(), Type: firstNonEmpty(call.typ, "function"), Name: name, Args: json.RawMessage(args)}
-		if !ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeToolCall, Data: []byte(args), ToolCall: toolCall}) {
+		if !emit(ai.Token{Type: ai.TokenTypeToolCall, Data: []byte(args), ToolCall: toolCall}) {
 			return false
 		}
 	}

--- a/ai/openai/model_test.go
+++ b/ai/openai/model_test.go
@@ -11,9 +11,11 @@ import (
 	"testing"
 
 	"github.com/lace-ai/gai/ai"
+	"github.com/lace-ai/gai/internal/obstest"
 )
 
 func TestModelGenerateMapsCapabilitiesAndResponse(t *testing.T) {
+	recorder := obstest.Install(t)
 	var got map[string]any
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/chat/completions" {
@@ -61,6 +63,10 @@ func TestModelGenerateMapsCapabilitiesAndResponse(t *testing.T) {
 	}
 	if len(res.ToolCalls) != 1 || res.ToolCalls[0].ID != "call_1" || res.ToolCalls[0].Name != "search" || string(res.ToolCalls[0].Args) != `{"query":"go"}` {
 		t.Fatalf("unexpected tool calls: %#v", res.ToolCalls)
+	}
+	attrs := obstest.Attributes(obstest.RequireGenerationSpans(t, recorder, 1)[0])
+	if attrs["gen_ai.provider.name"].AsString() != "openai" || attrs["gai.gen_ai.response.tool_call_count"].AsInt64() != 1 {
+		t.Fatalf("generation attrs = %#v", attrs)
 	}
 }
 
@@ -110,6 +116,7 @@ func TestModelGenerateWithResponsesTransportMapsToolContinuationAndNoneEffort(t 
 }
 
 func TestModelResponsesTransportDisablesResponseStorage(t *testing.T) {
+	recorder := obstest.Install(t)
 	requests := make(chan map[string]any, 2)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/responses" {
@@ -152,6 +159,14 @@ func TestModelResponsesTransportDisablesResponseStorage(t *testing.T) {
 		if !ok || !slices.Contains(include, any("reasoning.encrypted_content")) {
 			t.Fatalf("%s request include = %#v, want reasoning.encrypted_content", path, request["include"])
 		}
+	}
+	spans := obstest.RequireGenerationSpans(t, recorder, 2)
+	streaming := map[bool]int{}
+	for _, span := range spans {
+		streaming[obstest.Attributes(span)["gai.gen_ai.streaming"].AsBool()]++
+	}
+	if streaming[false] != 1 || streaming[true] != 1 {
+		t.Fatalf("Responses generation spans by streaming mode = %#v", streaming)
 	}
 }
 
@@ -480,11 +495,12 @@ func TestNativeMessagesMapToolErrorPayload(t *testing.T) {
 }
 
 func TestModelGenerateStreamMapsTextAndToolCalls(t *testing.T) {
+	recorder := obstest.Install(t)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"content\":\"hello \"}}]}\n\n"))
 		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"id\":\"call_1\",\"type\":\"function\",\"function\":{\"name\":\"search\",\"arguments\":\"{\\\"q\\\":\"}}]}}]}\n\n"))
-		_, _ = w.Write([]byte("data: {\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"go\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl_no_usage\",\"model\":\"resolved-no-usage\",\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"go\\\"}\"}}]},\"finish_reason\":\"tool_calls\"}]}\n\n"))
 		_, _ = w.Write([]byte("data: [DONE]\n\n"))
 	}))
 	defer ts.Close()
@@ -505,9 +521,50 @@ func TestModelGenerateStreamMapsTextAndToolCalls(t *testing.T) {
 	if call := tokens[1].ToolCall; tokens[1].Type != ai.TokenTypeToolCall || call == nil || call.ID != "call_1" || call.Name != "search" || string(call.Args) != `{"q":"go"}` {
 		t.Fatalf("unexpected tool token: %#v", tokens[1])
 	}
+	attrs := obstest.Attributes(obstest.RequireGenerationSpans(t, recorder, 1)[0])
+	if attrs["gen_ai.response.id"].AsString() != "chatcmpl_no_usage" || attrs["gen_ai.response.model"].AsString() != "resolved-no-usage" {
+		t.Fatalf("generation attrs = %#v", attrs)
+	}
+	if got := attrs["gen_ai.response.finish_reasons"].AsStringSlice(); len(got) != 1 || got[0] != "tool_calls" {
+		t.Fatalf("finish reasons = %v", got)
+	}
+	if _, ok := attrs["gen_ai.usage.input_tokens"]; ok {
+		t.Fatal("stream without usage emitted usage attributes")
+	}
+}
+
+func TestModelGenerateStreamUsesMetadataAfterUsageChunk(t *testing.T) {
+	recorder := obstest.Install(t)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl_early\",\"model\":\"early-model\",\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2}}\n\n"))
+		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl_final\",\"model\":\"resolved-final\",\"choices\":[{\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"))
+		_, _ = w.Write([]byte("data: [DONE]\n\n"))
+	}))
+	defer ts.Close()
+
+	p := New("test-key", nil)
+	p.baseURL = ts.URL
+	m, err := p.Model(GPT41Mini)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for token := range m.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+		if token.Type == ai.TokenTypeErr {
+			t.Fatalf("stream error: %v", token.Err)
+		}
+	}
+	attrs := obstest.Attributes(obstest.RequireGenerationSpans(t, recorder, 1)[0])
+	if attrs["gen_ai.response.id"].AsString() != "chatcmpl_final" || attrs["gen_ai.response.model"].AsString() != "resolved-final" || attrs["gen_ai.usage.input_tokens"].AsInt64() != 5 {
+		t.Fatalf("generation attrs = %#v", attrs)
+	}
+	if got := attrs["gen_ai.response.finish_reasons"].AsStringSlice(); len(got) != 1 || got[0] != "stop" {
+		t.Fatalf("finish reasons = %v", got)
+	}
 }
 
 func TestModelGenerateStreamPreservesUsageOnlyTerminalChunk(t *testing.T) {
+	recorder := obstest.Install(t)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		_, _ = w.Write([]byte("data: {\"id\":\"chatcmpl_1\",\"model\":\"gpt-4.1-mini\",\"choices\":[{\"delta\":{\"content\":\"hello\"},\"finish_reason\":\"stop\"}]}\n\n"))
@@ -532,6 +589,10 @@ func TestModelGenerateStreamPreservesUsageOnlyTerminalChunk(t *testing.T) {
 	completion := tokens[1].Completion
 	if completion == nil || completion.Usage.InputTokens != 11 || completion.Usage.OutputTokens != 7 || completion.Usage.ReasoningTokens != 3 || completion.Usage.CachedTokens != 2 || completion.FinishReason != "stop" || completion.RequestID != "chatcmpl_1" || completion.Provider != "openai" || completion.Model != GPT41Mini {
 		t.Fatalf("completion = %#v", completion)
+	}
+	attrs := obstest.Attributes(obstest.RequireGenerationSpans(t, recorder, 1)[0])
+	if !attrs["gai.gen_ai.streaming"].AsBool() || attrs["gen_ai.usage.output_tokens"].AsInt64() != 7 {
+		t.Fatalf("generation attrs = %#v", attrs)
 	}
 }
 

--- a/ai/openai/responses.go
+++ b/ai/openai/responses.go
@@ -13,11 +13,18 @@ import (
 	"github.com/openai/openai-go/shared"
 )
 
-func (m *Model) generateResponses(ctx context.Context, req ai.AIRequest) (*ai.AIResponse, error) {
+func (m *Model) generateResponses(ctx context.Context, req ai.AIRequest) (result *ai.AIResponse, err error) {
 	params, err := buildResponsesParams(m.name, req)
 	if err != nil {
 		return nil, err
 	}
+	ctx, observation := ai.StartGenerationObservation(ctx, req, ai.GenerationConfig{Provider: "openai", Model: m.name})
+	generationResult := ai.GenerationResult{}
+	defer func() {
+		generationResult.Err = err
+		generationResult.HTTPStatus = openAIHTTPStatus(err)
+		observation.Finish(generationResult)
+	}()
 	response, err := m.client(false).Responses.New(ctx, params)
 	if err != nil {
 		return nil, err
@@ -32,7 +39,21 @@ func (m *Model) generateResponses(ctx context.Context, req ai.AIRequest) (*ai.AI
 		}
 		return nil, fmt.Errorf("OpenAI Responses API: %s", message)
 	}
-	return responseFromResponses(response)
+	result, err = responseFromResponses(response)
+	if result != nil {
+		generationResult.ResponseModel = string(response.Model)
+		generationResult.RequestID = response.ID
+		generationResult.FinishReason = string(response.Status)
+		generationResult.ToolCallCount = len(result.ToolCalls)
+		if response.JSON.Usage.Valid() {
+			usage := ai.Usage{
+				InputTokens: result.InputTokens, OutputTokens: result.OutputTokens,
+				ReasoningTokens: result.ReasoningTokens, CachedTokens: int(response.Usage.InputTokensDetails.CachedTokens),
+			}
+			generationResult.Usage = &usage
+		}
+	}
+	return result, err
 }
 
 func (m *Model) generateResponsesStream(ctx context.Context, out chan<- ai.Token, req ai.AIRequest) {
@@ -40,6 +61,25 @@ func (m *Model) generateResponsesStream(ctx context.Context, out chan<- ai.Token
 	if err != nil {
 		ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
 		return
+	}
+	ctx, observation := ai.StartGenerationObservation(ctx, req, ai.GenerationConfig{Provider: "openai", Model: m.name, Streaming: true})
+	var streamErr error
+	generationResult := ai.GenerationResult{}
+	defer func() {
+		generationResult.Err = streamErr
+		generationResult.HTTPStatus = openAIHTTPStatus(streamErr)
+		observation.Finish(generationResult)
+	}()
+	emit := func(token ai.Token) bool {
+		if token.Type == ai.TokenTypeErr && token.Err != nil {
+			streamErr = token.Err
+		}
+		observation.ObserveToken(token)
+		if ai.SendToken(ctx, out, token) {
+			return true
+		}
+		streamErr = ctx.Err()
+		return false
 	}
 	stream := m.client(true).Responses.NewStreaming(ctx, params)
 	defer func() {
@@ -56,7 +96,23 @@ func (m *Model) generateResponsesStream(ctx context.Context, out chan<- ai.Token
 		event := stream.Current()
 		switch event.Type {
 		case "response.output_text.delta", "response.refusal.delta":
-			if text := event.Delta.OfString; text != "" && !ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeText, Data: []byte(text), Text: text}) {
+			if text := event.Delta.OfString; text != "" && !emit(ai.Token{Type: ai.TokenTypeText, Data: []byte(text), Text: text}) {
+				return
+			}
+		case "response.completed":
+			response := event.Response
+			completion := ai.Completion{
+				Provider: "openai", Model: string(response.Model), RequestID: response.ID,
+				FinishReason: string(response.Status), Raw: json.RawMessage(response.RawJSON()),
+			}
+			if response.JSON.Usage.Valid() {
+				completion.UsageReported = true
+				completion.Usage = ai.Usage{
+					InputTokens: int(response.Usage.InputTokens), OutputTokens: int(response.Usage.OutputTokens),
+					ReasoningTokens: int(response.Usage.OutputTokensDetails.ReasoningTokens), CachedTokens: int(response.Usage.InputTokensDetails.CachedTokens),
+				}
+			}
+			if !emit(ai.Token{Type: ai.TokenTypeCompletion, Completion: &completion}) {
 				return
 			}
 		case "response.output_item.done":
@@ -70,7 +126,8 @@ func (m *Model) generateResponsesStream(ctx context.Context, out chan<- ai.Token
 			args := json.RawMessage(event.Item.Arguments)
 			if !json.Valid(args) {
 				err := fmt.Errorf("invalid JSON arguments for tool %q", event.Item.Name)
-				ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
+				streamErr = err
+				emit(ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
 				return
 			}
 			var thoughtSignature []byte
@@ -78,17 +135,19 @@ func (m *Model) generateResponsesStream(ctx context.Context, out chan<- ai.Token
 				thoughtSignature, err = json.Marshal(reasoningItems)
 				if err != nil {
 					err = fmt.Errorf("encode OpenAI reasoning items: %w", err)
-					ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
+					streamErr = err
+					emit(ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
 					return
 				}
 			}
 			call := &ai.ToolCall{ID: event.Item.CallID, Type: "function", Name: event.Item.Name, Args: args, ThoughtSignature: append([]byte(nil), thoughtSignature...)}
-			if !ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeToolCall, Data: []byte(args), ToolCall: call}) {
+			if !emit(ai.Token{Type: ai.TokenTypeToolCall, Data: []byte(args), ToolCall: call}) {
 				return
 			}
 		case "error":
 			err := fmt.Errorf("OpenAI Responses API: %s", event.Message)
-			ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
+			streamErr = err
+			emit(ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
 			return
 		case "response.failed":
 			message := event.Response.Error.Message
@@ -99,12 +158,14 @@ func (m *Model) generateResponsesStream(ctx context.Context, out chan<- ai.Token
 				message = "response failed"
 			}
 			err := fmt.Errorf("OpenAI Responses API: %s", message)
-			ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
+			streamErr = err
+			emit(ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
 			return
 		}
 	}
 	if err := stream.Err(); err != nil {
-		ai.SendToken(ctx, out, ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
+		streamErr = err
+		emit(ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
 	}
 }
 

--- a/ai/response.go
+++ b/ai/response.go
@@ -47,12 +47,15 @@ func (u *Usage) Add(other Usage) {
 
 // Completion is terminal metadata emitted by a streaming provider request.
 type Completion struct {
-	Usage        Usage
-	FinishReason string
-	RequestID    string
-	Provider     string
-	Model        string
-	Raw          json.RawMessage
+	Usage Usage
+	// UsageReported distinguishes an absent provider usage block from a
+	// provider-reported usage block whose counters are all zero.
+	UsageReported bool
+	FinishReason  string
+	RequestID     string
+	Provider      string
+	Model         string
+	Raw           json.RawMessage
 }
 
 // TokenType identifies the semantic kind of a streamed token.

--- a/ai/response.go
+++ b/ai/response.go
@@ -145,9 +145,11 @@ func (r *AIResponse) AppendToken(t Token) {
 		}
 	case TokenTypeCompletion:
 		if t.Completion != nil {
-			r.InputTokens = t.Completion.Usage.InputTokens
-			r.OutputTokens = t.Completion.Usage.OutputTokens
-			r.ReasoningTokens = t.Completion.Usage.ReasoningTokens
+			if t.Completion.UsageReported {
+				r.InputTokens = t.Completion.Usage.InputTokens
+				r.OutputTokens = t.Completion.Usage.OutputTokens
+				r.ReasoningTokens = t.Completion.Usage.ReasoningTokens
+			}
 			r.FinishReason = t.Completion.FinishReason
 			r.Raw = append(r.Raw[:0], t.Completion.Raw...)
 		}

--- a/ai/response_test.go
+++ b/ai/response_test.go
@@ -54,14 +54,42 @@ func TestAIResponseAppendTokenCompletionUsesLatestUsage(t *testing.T) {
 	var response ai.AIResponse
 
 	response.AppendToken(ai.Token{Type: ai.TokenTypeCompletion, Completion: &ai.Completion{
-		Usage: ai.Usage{InputTokens: 10, OutputTokens: 4, ReasoningTokens: 2},
+		UsageReported: true,
+		Usage:         ai.Usage{InputTokens: 10, OutputTokens: 4, ReasoningTokens: 2},
 	}})
 	response.AppendToken(ai.Token{Type: ai.TokenTypeCompletion, Completion: &ai.Completion{
-		Usage: ai.Usage{InputTokens: 12, OutputTokens: 6, ReasoningTokens: 3},
+		UsageReported: true,
+		Usage:         ai.Usage{InputTokens: 12, OutputTokens: 6, ReasoningTokens: 3},
 	}})
 
 	if response.InputTokens != 12 || response.OutputTokens != 6 || response.ReasoningTokens != 3 {
 		t.Fatalf("completion usage should use the latest provider values, got %#v", response)
+	}
+}
+
+func TestAIResponseAppendTokenCompletionPreservesUnreportedUsage(t *testing.T) {
+	response := ai.AIResponse{InputTokens: 10, OutputTokens: 4, ReasoningTokens: 2}
+
+	response.AppendToken(ai.Token{Type: ai.TokenTypeCompletion, Completion: &ai.Completion{
+		FinishReason: "stop",
+		Raw:          json.RawMessage(`{"id":"response-1"}`),
+	}})
+
+	if response.InputTokens != 10 || response.OutputTokens != 4 || response.ReasoningTokens != 2 {
+		t.Fatalf("unreported completion usage should preserve accumulated values, got %#v", response)
+	}
+	if response.FinishReason != "stop" || string(response.Raw) != `{"id":"response-1"}` {
+		t.Fatalf("completion metadata should still be updated, got %#v", response)
+	}
+}
+
+func TestAIResponseAppendTokenCompletionAcceptsReportedZeroUsage(t *testing.T) {
+	response := ai.AIResponse{InputTokens: 10, OutputTokens: 4, ReasoningTokens: 2}
+
+	response.AppendToken(ai.Token{Type: ai.TokenTypeCompletion, Completion: &ai.Completion{UsageReported: true}})
+
+	if response.InputTokens != 0 || response.OutputTokens != 0 || response.ReasoningTokens != 0 {
+		t.Fatalf("reported zero usage should replace accumulated values, got %#v", response)
 	}
 }
 

--- a/internal/obstest/recorder.go
+++ b/internal/obstest/recorder.go
@@ -1,0 +1,73 @@
+// Package obstest provides OpenTelemetry assertions shared by provider tests.
+package obstest
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// Install installs an in-memory span recorder for the duration of the test.
+func Install(t testing.TB) *tracetest.SpanRecorder {
+	t.Helper()
+	previous := otel.GetTracerProvider()
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		otel.SetTracerProvider(previous)
+	})
+	return recorder
+}
+
+// RequireGenerationSpansEventually waits for asynchronous provider cleanup to
+// end exactly count generation spans.
+func RequireGenerationSpansEventually(t testing.TB, recorder *tracetest.SpanRecorder, count int, timeout time.Duration) []sdktrace.ReadOnlySpan {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		spans := generationSpans(recorder)
+		if len(spans) == count {
+			return spans
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("generation spans = %d, want %d before %s", len(spans), count, timeout)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// RequireGenerationSpans returns exactly count ended semantic generation spans.
+func RequireGenerationSpans(t testing.TB, recorder *tracetest.SpanRecorder, count int) []sdktrace.ReadOnlySpan {
+	t.Helper()
+	spans := generationSpans(recorder)
+	if len(spans) != count {
+		t.Fatalf("generation spans = %d, want %d", len(spans), count)
+	}
+	return spans
+}
+
+func generationSpans(recorder *tracetest.SpanRecorder) []sdktrace.ReadOnlySpan {
+	spans := make([]sdktrace.ReadOnlySpan, 0)
+	for _, span := range recorder.Ended() {
+		if Attributes(span)["langfuse.observation.type"].AsString() == "generation" {
+			spans = append(spans, span)
+		}
+	}
+	return spans
+}
+
+// Attributes returns span attributes indexed by key.
+func Attributes(span sdktrace.ReadOnlySpan) map[string]attribute.Value {
+	result := make(map[string]attribute.Value, len(span.Attributes()))
+	for _, attr := range span.Attributes() {
+		result[string(attr.Key)] = attr.Value
+	}
+	return result
+}

--- a/internal/obstest/recorder.go
+++ b/internal/obstest/recorder.go
@@ -13,6 +13,8 @@ import (
 )
 
 // Install installs an in-memory span recorder for the duration of the test.
+// It replaces the global OpenTelemetry tracer provider and must not be used
+// with t.Parallel() or concurrently with another Install call.
 func Install(t testing.TB) *tracetest.SpanRecorder {
 	t.Helper()
 	previous := otel.GetTracerProvider()

--- a/trace.go
+++ b/trace.go
@@ -15,13 +15,24 @@ import (
 var errSpanContextNotFound = errors.New("span context not found in context")
 
 func StartOperationSpan(ctx context.Context, tracerName string, spanPrefix string, operationAttr string, operation string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	return startOperationSpan(ctx, tracerName, spanPrefix+"."+operation, operationAttr, operation, nil, attrs...)
+}
+
+// StartClientOperationSpan starts an operation span representing a call to a
+// remote system while preserving GAI trace-context attributes.
+func StartClientOperationSpan(ctx context.Context, tracerName string, spanName string, operationAttr string, operation string, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
+	return startOperationSpan(ctx, tracerName, spanName, operationAttr, operation, []trace.SpanStartOption{trace.WithSpanKind(trace.SpanKindClient)}, attrs...)
+}
+
+func startOperationSpan(ctx context.Context, tracerName string, spanName string, operationAttr string, operation string, options []trace.SpanStartOption, attrs ...attribute.KeyValue) (context.Context, trace.Span) {
 	baseAttrs := []attribute.KeyValue{
 		attribute.String(operationAttr, operation),
 	}
 	baseAttrs = append(baseAttrs, attrs...)
 	baseAttrs = append(baseAttrs, traceContextAttributes(ctx)...)
 
-	return otel.Tracer(tracerName).Start(ctx, spanPrefix+"."+operation, trace.WithAttributes(baseAttrs...))
+	options = append(options, trace.WithAttributes(baseAttrs...))
+	return otel.Tracer(tracerName).Start(ctx, spanName, options...)
 }
 
 func EndSpan(span trace.Span, err error) {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent OpenTelemetry generation spans across supported AI providers.
  * Captured model, streaming, response, usage, tool-call, finish-reason, request, HTTP status, and error details.
  * Added first-output timing and improved streaming token and cancellation tracking.
  * Added client-operation span support for clearer tracing.

* **Documentation**
  * Documented generation span behavior, semantic attributes, Langfuse mappings, migration guidance, and sensitive-payload exclusions.

* **Bug Fixes**
  * Improved handling of missing or zero-valued provider usage data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a shared `GenerationObservation` abstraction in `ai/generation_observation.go` that replaces per-provider ad-hoc OTel spans with a uniform `gen_ai.*` + Langfuse attribute contract across all four providers (OpenAI Chat, OpenAI Responses, Anthropic, Gemini, Mistral). It also adds a `UsageReported` sentinel to `Completion` so that missing provider usage is distinguished from a legitimately zero-valued report.

- **New `GenerationObservation` type**: starts a `SpanKindClient` span named `chat {model}`, accumulates streaming token metadata via `ObserveToken`, records first-output timing, and emits `gen_ai.usage.*`, `langfuse.observation.*`, `error.type`, and `http.response.status_code` attributes on `Finish`.
- **All four providers migrated**: old `StartOperationSpan` calls removed; each provider now calls `StartGenerationObservation` + `Finish` in a defer, with `HTTPStatus` and `ResponseModel` extracted from the provider response.
- **`Completion.UsageReported` gate**: `AppendToken` now only zeros out accumulated token counts when a completion token explicitly reports usage, preventing identity-only chunks from resetting correct counts.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the OpenAI streaming emit functions; all other provider paths and the core abstraction are correct.

Both OpenAI streaming paths have an emit lambda that unconditionally assigns streamErr = ctx.Err() when the output channel cannot accept a token. If a provider error was recorded in streamErr on the line immediately above, the context-cancellation error silently replaces it, causing the generation span to report the wrong error.type. The other three providers guard this assignment with if streamErr == nil, which is the correct pattern. All other changes are correct.

**Files Needing Attention:** ai/openai/model.go and ai/openai/responses.go — both streaming emit lambdas need the if streamErr == nil guard before streamErr = ctx.Err().

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ai/generation_observation.go | New file introducing `GenerationObservation`, the central abstraction for provider-neutral gen_ai spans. All methods are correctly guarded for nil receivers and implement the expected Langfuse/OTel attribute contract. |
| ai/openai/model.go | Migrates OpenAI Chat Completions to `GenerationObservation`. The streaming `emit` lambda unconditionally overwrites `streamErr` with `ctx.Err()` on channel-send failure, which can replace a previously captured provider error and produce incorrect `error.type` in the span. |
| ai/openai/responses.go | Adds `GenerationObservation` to Responses API and introduces `response.completed` completion-token emission. Same unconditional `streamErr = ctx.Err()` pattern as model.go; all other changes look correct. |
| ai/anthropic/model.go | Replaces the old operation span with `GenerationObservation`, captures Anthropic-specific usage correctly, and uses the correct `if streamErr == nil` guard in the streaming path. |
| ai/gemini/model.go | Migrates both `Generate` and `GenerateStream` to `GenerationObservation`. All nil-safety and defer ordering look correct. |
| ai/mistral/model.go | Migrates both Mistral paths cleanly. The new `emitCompletion` defer correctly runs before `observation.Finish` (LIFO), so completion metadata flows through `ObserveToken` before the span ends. |
| ai/response.go | Adds `UsageReported` to `Completion` and gates `AppendToken`'s usage update on it, correctly distinguishing absent usage from a provider-reported zero. |
| internal/obstest/recorder.go | New shared test helper for span assertions. The existing PR thread notes the missing over-count fast-fail in `RequireGenerationSpansEventually` — no new issues here. |
| trace.go | Adds `StartClientOperationSpan` (SpanKindClient) and refactors the shared internal helper. Minimal and backward-compatible. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Provider as Provider (OpenAI/Anthropic/Gemini/Mistral)
    participant GO as GenerationObservation
    participant Span as OTel Span (Langfuse)

    Caller->>Provider: Generate / GenerateStream
    Provider->>GO: StartGenerationObservation(ctx, req, config)
    GO->>Span: StartClientOperationSpan
    GO-->>Provider: ctx, observation

    alt Streaming
        loop each token
            Provider->>GO: ObserveToken(token)
            GO->>Span: FirstOutput() on first meaningful token
        end
        Provider->>GO: ObserveToken(TokenTypeCompletion)
        GO-->>GO: store usage/model/requestID in stream
    else Non-streaming
        Provider->>Provider: fill generationResult directly
    end

    Provider->>GO: Finish(generationResult)
    GO-->>GO: mergeGenerationResults(stream, final)
    GO->>Span: SetAttributes + EndSpan
    Span-->>Caller: exported to Langfuse
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
ai/openai/responses.go:73-83
Same unconditional `streamErr = ctx.Err()` pattern as in the Chat Completions streaming path. When the channel send races with context cancellation after an error event has already been captured, the original provider error is overwritten, producing incorrect `error.type` telemetry in the generation span.

```suggestion
	emit := func(token ai.Token) bool {
		if token.Type == ai.TokenTypeErr && token.Err != nil {
			streamErr = token.Err
		}
		observation.ObserveToken(token)
		if ai.SendToken(ctx, out, token) {
			return true
		}
		if streamErr == nil {
			streamErr = ctx.Err()
		}
		return false
	}
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (4): Last reviewed commit: ["fix findings"](https://github.com/lace-ai/gai/commit/34af5aef218e067532cf187990c9810b5c21cf40) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49314003)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->