### PR TITLE
feat(obs) content

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,47 @@ The older `ai.provider`, `ai.model`, `ai.max_tokens`, `ai.input_tokens`,
 remain during the semantic-attribute migration. New integrations should use
 the `gen_ai.*` attributes.
 
+Every tool invocation executed through `Loop` creates one `loop.tool` child
+span. Direct calls to `CallTool` are not instrumented.
+
+| Attribute | Value |
+| --- | --- |
+| `loop.operation` | `tool` |
+| `gen_ai.operation.name` | `execute_tool` |
+| `gen_ai.tool.name`, `gen_ai.tool.call.id` | Stable tool name and model-issued call ID |
+| `gen_ai.tool.type` | `function` |
+| `langfuse.observation.type` | `tool` |
+| `gai.tool.outcome` | `success`, `tool_error`, `panic`, `deadline`, `cancellation`, or `missing_response` |
+| `error.type` | Fixed `gai.tool.*` classification on failures |
+| `tool.name`, `tool.call_id`, `tool.status` | Legacy compatibility attributes |
+
+Span errors use fixed, low-cardinality classifications; raw tool errors and
+panic values are never exported implicitly. A panic is recorded and then
+rethrown unchanged.
+
+Tool arguments and results are absent by default. Enable them independently
+with the same request-scoped capture policy used for other sensitive content:
+
+```go
+ctx = gai.WithContentCapturePolicy(ctx, gai.ContentCapturePolicy{
+  ToolInput:  gai.CaptureEnabled,
+  ToolOutput: gai.CaptureEnabled,
+  MaxBytes:   4096,
+  Redact: func(ctx context.Context, kind gai.ContentKind, value []byte) ([]byte, error) {
+    return redactApplicationSecrets(value), nil
+  },
+})
+```
+
+Captured input is written to `gen_ai.tool.call.arguments` and
+`langfuse.observation.input`; captured output is written to
+`langfuse.observation.output`, and successful output is also written to
+`gen_ai.tool.call.result`. The legacy `tool.input` and `tool.output` attributes
+remain during migration and carry the redaction, truncation, and byte-count
+metadata. Content is captured once and reused for every applicable alias.
+Valid JSON remains serialized JSON; invalid JSON is retained as bounded UTF-8
+text. Redactor errors and panics fail closed.
+
 ## Package map
 
 ```text

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -452,9 +452,7 @@ func (l *Loop) executeToolCalls(ctx context.Context, iteration *Iteration, toolC
 		go func(tc pendingToolCall) {
 			defer wg.Done()
 
-			toolCtx, finishToolSpan := startToolSpan(ctx, tc.call)
-			toolRes := CallTool(toolCtx, &tc.call, l.Tools)
-			finishToolSpan(toolRes)
+			toolRes := callObservedTool(ctx, tc.call, l.Tools)
 			iteration.Parts[tc.partIndex].ToolResp = toolRes
 			if l.ToolResponseProcessor != nil {
 				if err := l.ToolResponseProcessor.Process(tc.call, toolRes); err != nil {

--- a/loop/loop_obs.go
+++ b/loop/loop_obs.go
@@ -314,7 +314,7 @@ func (o *toolObservation) finish(response *ToolResponse, missingResponse bool) {
 	}
 	o.finishOnce.Do(func() {
 		outcome, output, spanErr := toolResult(response, missingResponse)
-		if response != nil {
+		if response != nil && outcome != toolOutcomeMissingResponse {
 			if captured, ok := gai.CaptureContent(o.ctx, gai.ContentKindToolOutput, []byte(output)); ok {
 				aliases := []string{"langfuse.observation.output"}
 				if outcome == toolOutcomeSuccess {

--- a/loop/loop_obs.go
+++ b/loop/loop_obs.go
@@ -3,6 +3,7 @@ package loop
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/lace-ai/gai"
 	"github.com/lace-ai/gai/ai"
@@ -12,7 +13,22 @@ import (
 
 const loopTracerName = "github.com/lace-ai/gai/loop"
 
-var errObservedToolExecution = errors.New("tool execution failed")
+const (
+	toolOutcomeSuccess         = "success"
+	toolOutcomeError           = "tool_error"
+	toolOutcomePanic           = "panic"
+	toolOutcomeDeadline        = "deadline"
+	toolOutcomeCancellation    = "cancellation"
+	toolOutcomeMissingResponse = "missing_response"
+)
+
+var (
+	errObservedToolExecution       = errors.New("tool execution failed")
+	errObservedToolPanic           = errors.New("tool execution panicked")
+	errObservedToolDeadline        = errors.New("tool execution deadline exceeded")
+	errObservedToolCancellation    = errors.New("tool execution canceled")
+	errObservedToolMissingResponse = errors.New("tool response missing")
+)
 
 type loopRunState struct {
 	obs        *loopObserver
@@ -253,52 +269,117 @@ func (o *iterationObserver) finish(err error, stats loopIterationStats) {
 	gai.EndSpan(o.span, err)
 }
 
-func startToolSpan(ctx context.Context, call ai.ToolCall) (context.Context, func(*ToolResponse)) {
+type toolObservation struct {
+	ctx        context.Context
+	span       trace.Span
+	finishOnce sync.Once
+}
+
+func startToolSpan(ctx context.Context, call ai.ToolCall) (context.Context, *toolObservation) {
 	ctx, span := gai.StartOperationSpan(ctx, loopTracerName, "loop", "loop.operation", "tool",
 		attribute.String("tool.name", call.Name),
 		attribute.String("tool.call_id", call.ID),
+		attribute.String("gen_ai.operation.name", "execute_tool"),
+		attribute.String("gen_ai.tool.name", call.Name),
+		attribute.String("gen_ai.tool.type", "function"),
+		attribute.String("gen_ai.tool.call.id", call.ID),
+		attribute.String("langfuse.observation.type", "tool"),
 	)
 	if captured, ok := gai.CaptureContent(ctx, gai.ContentKindToolInput, call.Args); ok {
-		setCapturedToolContent(span, "tool.input", captured)
+		setCapturedToolContent(span, "tool.input", captured,
+			"gen_ai.tool.call.arguments",
+			"langfuse.observation.input",
+		)
 	}
-	return ctx, func(response *ToolResponse) {
-		status := "success"
-		var executionErr error
-		var output string
-		if response == nil {
-			status = "error"
-			executionErr = ErrToolErrorMissing
-		} else if responseErr := response.ErrorValue(); responseErr != nil {
-			status = "error"
-			executionErr = responseErr
-			output = responseErr.Error()
-		} else {
-			output = response.TextValue()
+	return ctx, &toolObservation{ctx: ctx, span: span}
+}
+
+func callObservedTool(ctx context.Context, call ai.ToolCall, tools []Tool) (response *ToolResponse) {
+	toolCtx, observation := startToolSpan(ctx, call)
+	missingResponse := false
+	defer func() {
+		if panicValue := recover(); panicValue != nil {
+			observation.finishPanic()
+			panic(panicValue)
 		}
+		observation.finish(response, missingResponse)
+	}()
+	response, missingResponse = callTool(toolCtx, &call, tools)
+	return response
+}
+
+func (o *toolObservation) finish(response *ToolResponse, missingResponse bool) {
+	if o == nil {
+		return
+	}
+	o.finishOnce.Do(func() {
+		outcome, output, spanErr := toolResult(response, missingResponse)
 		if response != nil {
-			if captured, ok := gai.CaptureContent(ctx, gai.ContentKindToolOutput, []byte(output)); ok {
-				setCapturedToolContent(span, "tool.output", captured)
+			if captured, ok := gai.CaptureContent(o.ctx, gai.ContentKindToolOutput, []byte(output)); ok {
+				aliases := []string{"langfuse.observation.output"}
+				if outcome == toolOutcomeSuccess {
+					aliases = append(aliases, "gen_ai.tool.call.result")
+				}
+				setCapturedToolContent(o.span, "tool.output", captured, aliases...)
 			}
 		}
-		span.SetAttributes(attribute.String("tool.status", status))
-		if response == nil {
-			gai.EndSpan(span, ErrToolErrorMissing)
-			return
-		}
-		if executionErr != nil {
-			gai.EndSpan(span, errObservedToolExecution)
-			return
-		}
-		gai.EndSpan(span, nil)
+		o.setOutcome(outcome, spanErr)
+	})
+}
+
+func (o *toolObservation) finishPanic() {
+	if o == nil {
+		return
+	}
+	o.finishOnce.Do(func() {
+		o.setOutcome(toolOutcomePanic, errObservedToolPanic)
+	})
+}
+
+func (o *toolObservation) setOutcome(outcome string, spanErr error) {
+	status := "success"
+	attrs := []attribute.KeyValue{attribute.String("gai.tool.outcome", outcome)}
+	if spanErr != nil {
+		status = "error"
+		attrs = append(attrs, attribute.String("error.type", "gai.tool."+outcome))
+	}
+	attrs = append(attrs, attribute.String("tool.status", status))
+	o.span.SetAttributes(attrs...)
+	gai.EndSpan(o.span, spanErr)
+}
+
+func toolResult(response *ToolResponse, missingResponse bool) (outcome string, output string, spanErr error) {
+	if missingResponse || response == nil {
+		return toolOutcomeMissingResponse, "", errObservedToolMissingResponse
+	}
+	responseErr := response.ErrorValue()
+	if responseErr == nil && response.Status == "error" {
+		responseErr = ErrToolErrorMissing
+	}
+	if responseErr == nil {
+		return toolOutcomeSuccess, response.TextValue(), nil
+	}
+	output = responseErr.Error()
+	switch {
+	case errors.Is(responseErr, context.DeadlineExceeded):
+		return toolOutcomeDeadline, output, errObservedToolDeadline
+	case errors.Is(responseErr, context.Canceled):
+		return toolOutcomeCancellation, output, errObservedToolCancellation
+	default:
+		return toolOutcomeError, output, errObservedToolExecution
 	}
 }
 
-func setCapturedToolContent(span trace.Span, prefix string, captured gai.CapturedContent) {
-	span.SetAttributes(
+func setCapturedToolContent(span trace.Span, prefix string, captured gai.CapturedContent, aliases ...string) {
+	attrs := []attribute.KeyValue{
 		attribute.String(prefix, string(captured.Value)),
 		attribute.Int(prefix+".original_bytes", captured.OriginalBytes),
 		attribute.Int(prefix+".captured_bytes", captured.CapturedBytes),
 		attribute.Bool(prefix+".truncated", captured.Truncated),
 		attribute.Bool(prefix+".redaction_applied", captured.RedactionApplied),
-	)
+	}
+	for _, alias := range aliases {
+		attrs = append(attrs, attribute.String(alias, string(captured.Value)))
+	}
+	span.SetAttributes(attrs...)
 }

--- a/loop/loop_obs_internal_test.go
+++ b/loop/loop_obs_internal_test.go
@@ -120,6 +120,26 @@ func TestObservedToolPanicFinalizesAndRepanics(t *testing.T) {
 	}
 }
 
+func TestToolObservationMissingResponseOmitsOutput(t *testing.T) {
+	recorder := obstest.Install(t)
+	ctx := gai.WithContentCapturePolicy(t.Context(), gai.ContentCapturePolicy{ToolOutput: gai.CaptureEnabled})
+	call := ai.ToolCall{ID: "call-missing", Type: "function", Name: "missing", Args: json.RawMessage(`{}`)}
+	tool := observedTestTool{name: "missing", call: func(context.Context, *ai.ToolCall) *ToolResponse {
+		return nil
+	}}
+	callObservedTool(ctx, call, []Tool{tool})
+
+	attrs := obstest.Attributes(requireToolSpans(t, recorder, 1)[0])
+	if got := attrs["gai.tool.outcome"].AsString(); got != toolOutcomeMissingResponse {
+		t.Fatalf("gai.tool.outcome = %q, want %q", got, toolOutcomeMissingResponse)
+	}
+	for _, key := range []string{"tool.output", "gen_ai.tool.call.result", "langfuse.observation.output"} {
+		if _, ok := attrs[key]; ok {
+			t.Fatalf("missing response exported %q: %#v", key, attrs[key])
+		}
+	}
+}
+
 func TestToolObservationUsesPolicyGatedContentAliases(t *testing.T) {
 	recorder := obstest.Install(t)
 	ctx := gai.WithContentCapturePolicy(t.Context(), gai.ContentCapturePolicy{

--- a/loop/loop_obs_internal_test.go
+++ b/loop/loop_obs_internal_test.go
@@ -2,34 +2,306 @@ package loop
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/lace-ai/gai"
 	"github.com/lace-ai/gai/ai"
+	"github.com/lace-ai/gai/internal/obstest"
 	"go.opentelemetry.io/otel"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
-func TestToolSpanPreservesMissingResponseError(t *testing.T) {
-	previousProvider := otel.GetTracerProvider()
-	recorder := tracetest.NewSpanRecorder()
-	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
-	otel.SetTracerProvider(provider)
-	t.Cleanup(func() {
-		_ = provider.Shutdown(context.Background())
-		otel.SetTracerProvider(previousProvider)
-	})
+type observedTestTool struct {
+	name string
+	call func(context.Context, *ai.ToolCall) *ToolResponse
+}
 
-	_, finish := startToolSpan(t.Context(), ai.ToolCall{ID: "call-missing", Name: "missing"})
-	finish(nil)
+func (t observedTestTool) Name() string              { return t.name }
+func (t observedTestTool) Description() string       { return "Test tool." }
+func (t observedTestTool) Params() ai.ToolParameters { return NewEchoTool().Params() }
+func (t observedTestTool) Function(ctx context.Context, call *ai.ToolCall) *ToolResponse {
+	return t.call(ctx, call)
+}
 
-	for _, span := range recorder.Ended() {
-		if span.Name() == "loop.tool" {
-			if got := span.Status().Description; got != ErrToolErrorMissing.Error() {
-				t.Fatalf("tool span status = %q, want %q", got, ErrToolErrorMissing)
+func TestToolObservationOutcomes(t *testing.T) {
+	tests := []struct {
+		name    string
+		ctx     func(*testing.T) context.Context
+		call    func(context.Context, *ai.ToolCall) *ToolResponse
+		outcome string
+	}{
+		{name: "success", call: func(context.Context, *ai.ToolCall) *ToolResponse {
+			return NewToolSuccess("ok")
+		}, outcome: toolOutcomeSuccess},
+		{name: "tool error", call: func(context.Context, *ai.ToolCall) *ToolResponse {
+			return NewToolError(errors.New("tool-error-sentinel-secret"))
+		}, outcome: toolOutcomeError},
+		{name: "deadline", ctx: func(t *testing.T) context.Context {
+			ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+			t.Cleanup(cancel)
+			return ctx
+		}, call: func(ctx context.Context, _ *ai.ToolCall) *ToolResponse {
+			return NewToolError(fmt.Errorf("wrapped: %w", ctx.Err()))
+		}, outcome: toolOutcomeDeadline},
+		{name: "cancellation", ctx: func(t *testing.T) context.Context {
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+			return ctx
+		}, call: func(ctx context.Context, _ *ai.ToolCall) *ToolResponse {
+			return NewToolError(fmt.Errorf("wrapped: %w", ctx.Err()))
+		}, outcome: toolOutcomeCancellation},
+		{name: "missing response", call: func(context.Context, *ai.ToolCall) *ToolResponse {
+			return nil
+		}, outcome: toolOutcomeMissingResponse},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			recorder := obstest.Install(t)
+			ctx := t.Context()
+			if tt.ctx != nil {
+				ctx = tt.ctx(t)
 			}
-			return
+			call := ai.ToolCall{ID: "call-1", Type: "function", Name: "test", Args: json.RawMessage(`{}`)}
+			response := callObservedTool(ctx, call, []Tool{observedTestTool{name: "test", call: tt.call}})
+			if response == nil {
+				t.Fatal("observed tool returned nil response")
+			}
+
+			span := requireToolSpans(t, recorder, 1)[0]
+			attrs := obstest.Attributes(span)
+			if got := attrs["gai.tool.outcome"].AsString(); got != tt.outcome {
+				t.Fatalf("gai.tool.outcome = %q, want %q", got, tt.outcome)
+			}
+			wantStatus := "error"
+			if tt.outcome == toolOutcomeSuccess {
+				wantStatus = "success"
+			}
+			if got := attrs["tool.status"].AsString(); got != wantStatus {
+				t.Fatalf("tool.status = %q, want %q", got, wantStatus)
+			}
+			if strings.Contains(toolSpanText(span), "sentinel-secret") {
+				t.Fatalf("raw tool error reached span: %s", toolSpanText(span))
+			}
+		})
+	}
+}
+
+func TestObservedToolPanicFinalizesAndRepanics(t *testing.T) {
+	recorder := obstest.Install(t)
+	panicValue := errors.New("panic-sentinel-secret")
+	call := ai.ToolCall{ID: "call-panic", Type: "function", Name: "panic", Args: json.RawMessage(`{}`)}
+	tool := observedTestTool{name: "panic", call: func(context.Context, *ai.ToolCall) *ToolResponse {
+		panic(panicValue)
+	}}
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		callObservedTool(t.Context(), call, []Tool{tool})
+	}()
+	if recovered != panicValue {
+		t.Fatalf("recovered panic = %#v, want original value", recovered)
+	}
+
+	span := requireToolSpans(t, recorder, 1)[0]
+	attrs := obstest.Attributes(span)
+	if attrs["gai.tool.outcome"].AsString() != toolOutcomePanic || attrs["error.type"].AsString() != "gai.tool.panic" {
+		t.Fatalf("panic span attributes = %#v", attrs)
+	}
+	if strings.Contains(toolSpanText(span), "panic-sentinel-secret") {
+		t.Fatalf("panic value reached span: %s", toolSpanText(span))
+	}
+}
+
+func TestToolObservationUsesPolicyGatedContentAliases(t *testing.T) {
+	recorder := obstest.Install(t)
+	ctx := gai.WithContentCapturePolicy(t.Context(), gai.ContentCapturePolicy{
+		ToolInput: gai.CaptureEnabled, ToolOutput: gai.CaptureEnabled,
+		Redact: func(_ context.Context, _ gai.ContentKind, value []byte) ([]byte, error) {
+			return []byte(strings.ReplaceAll(string(value), "secret", "[redacted]")), nil
+		},
+	})
+	call := ai.ToolCall{ID: "call-content", Type: "function", Name: "content", Args: json.RawMessage(`{"text":"secret"}`)}
+	tool := observedTestTool{name: "content", call: func(context.Context, *ai.ToolCall) *ToolResponse {
+		return NewToolSuccess(`{"result":"secret"}`)
+	}}
+	callObservedTool(ctx, call, []Tool{tool})
+
+	attrs := obstest.Attributes(requireToolSpans(t, recorder, 1)[0])
+	wantInput := `{"text":"[redacted]"}`
+	for _, key := range []string{"tool.input", "gen_ai.tool.call.arguments", "langfuse.observation.input"} {
+		if got := attrs[key].AsString(); got != wantInput {
+			t.Fatalf("%s = %q, want %q", key, got, wantInput)
 		}
 	}
-	t.Fatal("loop.tool span was not recorded")
+	wantOutput := `{"result":"[redacted]"}`
+	for _, key := range []string{"tool.output", "gen_ai.tool.call.result", "langfuse.observation.output"} {
+		if got := attrs[key].AsString(); got != wantOutput {
+			t.Fatalf("%s = %q, want %q", key, got, wantOutput)
+		}
+	}
+	if !attrs["tool.input.redaction_applied"].AsBool() || !attrs["tool.output.redaction_applied"].AsBool() {
+		t.Fatalf("redaction metadata missing: %#v", attrs)
+	}
+	if attrs["langfuse.observation.type"].AsString() != "tool" || attrs["gen_ai.operation.name"].AsString() != "execute_tool" {
+		t.Fatalf("semantic tool attributes missing: %#v", attrs)
+	}
+}
+
+func TestToolObservationCapturesInvalidJSONAndTruncatesLargeValues(t *testing.T) {
+	t.Run("invalid JSON", func(t *testing.T) {
+		recorder := obstest.Install(t)
+		ctx := gai.WithContentCapturePolicy(t.Context(), gai.ContentCapturePolicy{ToolInput: gai.CaptureEnabled})
+		call := ai.ToolCall{ID: "call-invalid", Type: "function", Name: "content", Args: json.RawMessage(`{"broken"`)}
+		tool := observedTestTool{name: "content", call: func(context.Context, *ai.ToolCall) *ToolResponse {
+			return NewToolSuccess("ok")
+		}}
+		callObservedTool(ctx, call, []Tool{tool})
+
+		attrs := obstest.Attributes(requireToolSpans(t, recorder, 1)[0])
+		if got := attrs["gen_ai.tool.call.arguments"].AsString(); got != `{"broken"` {
+			t.Fatalf("captured invalid JSON = %q", got)
+		}
+	})
+
+	t.Run("large values", func(t *testing.T) {
+		recorder := obstest.Install(t)
+		ctx := gai.WithContentCapturePolicy(t.Context(), gai.ContentCapturePolicy{
+			ToolInput: gai.CaptureEnabled, ToolOutput: gai.CaptureEnabled, MaxBytes: 24,
+		})
+		call := ai.ToolCall{ID: "call-large", Type: "function", Name: "content", Args: json.RawMessage(`{"text":"abcdefghijklmnopqrstuvwxyz"}`)}
+		tool := observedTestTool{name: "content", call: func(context.Context, *ai.ToolCall) *ToolResponse {
+			return NewToolSuccess(strings.Repeat("x", 64))
+		}}
+		callObservedTool(ctx, call, []Tool{tool})
+
+		attrs := obstest.Attributes(requireToolSpans(t, recorder, 1)[0])
+		if !attrs["tool.input.truncated"].AsBool() || !attrs["tool.output.truncated"].AsBool() {
+			t.Fatalf("truncation metadata missing: %#v", attrs)
+		}
+		if got := len(attrs["langfuse.observation.input"].AsString()); got > 24 {
+			t.Fatalf("captured input bytes = %d, want <= 24", got)
+		}
+		if got := len(attrs["langfuse.observation.output"].AsString()); got > 24 {
+			t.Fatalf("captured output bytes = %d, want <= 24", got)
+		}
+	})
+}
+
+func TestToolObservationOmitsContentByDefault(t *testing.T) {
+	recorder := obstest.Install(t)
+	call := ai.ToolCall{ID: "call-private", Type: "function", Name: "content", Args: json.RawMessage(`{"secret":"input"}`)}
+	tool := observedTestTool{name: "content", call: func(context.Context, *ai.ToolCall) *ToolResponse {
+		return NewToolSuccess("output-secret")
+	}}
+	callObservedTool(t.Context(), call, []Tool{tool})
+
+	attrs := obstest.Attributes(requireToolSpans(t, recorder, 1)[0])
+	for _, key := range []string{
+		"tool.input", "gen_ai.tool.call.arguments", "langfuse.observation.input",
+		"tool.output", "gen_ai.tool.call.result", "langfuse.observation.output",
+	} {
+		if _, ok := attrs[key]; ok {
+			t.Fatalf("disabled content attribute %q was exported: %#v", key, attrs[key])
+		}
+	}
+}
+
+func TestToolObservationFinishesOnce(t *testing.T) {
+	recorder := obstest.Install(t)
+	_, observation := startToolSpan(t.Context(), ai.ToolCall{ID: "call-once", Name: "once"})
+	observation.finish(NewToolSuccess("ok"), false)
+	observation.finish(NewToolError(errors.New("late error")), false)
+	observation.finishPanic()
+
+	span := requireToolSpans(t, recorder, 1)[0]
+	if got := obstest.Attributes(span)["gai.tool.outcome"].AsString(); got != toolOutcomeSuccess {
+		t.Fatalf("gai.tool.outcome = %q, want first result %q", got, toolOutcomeSuccess)
+	}
+}
+
+func TestExecuteToolCallsCreatesConcurrentChildSpans(t *testing.T) {
+	recorder := obstest.Install(t)
+	entered := make(chan string, 2)
+	release := make(chan struct{})
+	tool := observedTestTool{name: "concurrent", call: func(_ context.Context, call *ai.ToolCall) *ToolResponse {
+		entered <- call.ID
+		<-release
+		return NewToolSuccess(call.ID)
+	}}
+	l := &Loop{Tools: []Tool{tool}}
+	iteration := &Iteration{Parts: make([]IterationPart, 2)}
+	calls := []pendingToolCall{
+		{partIndex: 0, call: ai.ToolCall{ID: "call-1", Type: "function", Name: "concurrent", Args: json.RawMessage(`{}`)}},
+		{partIndex: 1, call: ai.ToolCall{ID: "call-2", Type: "function", Name: "concurrent", Args: json.RawMessage(`{}`)}},
+	}
+	ctx, parent := otel.Tracer("test").Start(t.Context(), "loop.iteration")
+	done := make(chan error, 1)
+	go func() { done <- l.executeToolCalls(ctx, iteration, calls) }()
+
+	seen := map[string]bool{}
+	for range calls {
+		select {
+		case id := <-entered:
+			seen[id] = true
+		case <-time.After(time.Second):
+			t.Fatal("tool calls did not overlap")
+		}
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("executeToolCalls error: %v", err)
+	}
+	parent.End()
+	if !seen["call-1"] || !seen["call-2"] {
+		t.Fatalf("executed calls = %#v", seen)
+	}
+
+	spans := requireToolSpans(t, recorder, 2)
+	for _, span := range spans {
+		if span.Parent().SpanID() != parent.SpanContext().SpanID() {
+			t.Fatalf("tool span parent = %s, want %s", span.Parent().SpanID(), parent.SpanContext().SpanID())
+		}
+		if obstest.Attributes(span)["gai.tool.outcome"].AsString() != toolOutcomeSuccess {
+			t.Fatalf("tool span outcome = %#v", obstest.Attributes(span))
+		}
+	}
+}
+
+func requireToolSpans(t testing.TB, recorder *tracetest.SpanRecorder, count int) []sdktrace.ReadOnlySpan {
+	t.Helper()
+	spans := make([]sdktrace.ReadOnlySpan, 0, count)
+	for _, span := range recorder.Ended() {
+		if span.Name() == "loop.tool" {
+			spans = append(spans, span)
+		}
+	}
+	if len(spans) != count {
+		t.Fatalf("tool spans = %d, want %d", len(spans), count)
+	}
+	return spans
+}
+
+func toolSpanText(span sdktrace.ReadOnlySpan) string {
+	var text strings.Builder
+	text.WriteString(span.Status().Description)
+	for _, attr := range span.Attributes() {
+		text.WriteString(string(attr.Key))
+		text.WriteString(attr.Value.Emit())
+	}
+	for _, event := range span.Events() {
+		text.WriteString(event.Name)
+		for _, attr := range event.Attributes {
+			text.WriteString(string(attr.Key))
+			text.WriteString(attr.Value.Emit())
+		}
+	}
+	return text.String()
 }

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -1297,7 +1297,15 @@ func TestLoopCreatesToolSpans(t *testing.T) {
 		if attributes["tool.input.redaction_applied"] != true || attributes["tool.output.redaction_applied"] != true {
 			t.Fatalf("tool span is missing redaction metadata: %#v", attributes)
 		}
-		return
+		if attributes["gen_ai.operation.name"] != "execute_tool" || attributes["langfuse.observation.type"] != "tool" {
+			t.Fatalf("tool span is missing semantic attributes: %#v", attributes)
+		}
+		for _, candidate := range recorder.Ended() {
+			if candidate.Name() == "loop.iteration" && candidate.SpanContext().SpanID() == span.Parent().SpanID() {
+				return
+			}
+		}
+		t.Fatalf("tool span parent %s is not a loop.iteration span", span.Parent().SpanID())
 	}
 	t.Fatalf("expected loop.tool span, got %#v", recorder.Ended())
 }

--- a/loop/tool.go
+++ b/loop/tool.go
@@ -68,24 +68,29 @@ type Tool interface {
 // It returns an error response when validation fails, no tool matches, or a
 // tool returns nil.
 func CallTool(ctx context.Context, req *ai.ToolCall, tools []Tool) *ToolResponse {
+	response, _ := callTool(ctx, req, tools)
+	return response
+}
+
+func callTool(ctx context.Context, req *ai.ToolCall, tools []Tool) (*ToolResponse, bool) {
 	if err := req.Validate(); err != nil {
-		return NewToolError(err)
+		return NewToolError(err), false
 	}
 
 	for index, tool := range tools {
 		if tool == nil {
-			return NewToolError(fmt.Errorf("%w: tool at index %d is nil", ai.ErrInvalidToolDefinition, index))
+			return NewToolError(fmt.Errorf("%w: tool at index %d is nil", ai.ErrInvalidToolDefinition, index)), false
 		}
 		if tool.Name() == req.Name {
 			res := tool.Function(ctx, req)
 			if res == nil {
-				return NewToolError(fmt.Errorf("tool %s returned nil response", req.Name))
+				return NewToolError(fmt.Errorf("tool %s returned nil response", req.Name)), true
 			}
-			return res
+			return res, false
 		}
 	}
 
-	return NewToolError(fmt.Errorf("%w: %s", ErrToolNotFound, req.Name))
+	return NewToolError(fmt.Errorf("%w: %s", ErrToolNotFound, req.Name)), false
 }
 
 // DecodeToolArgs validates req and decodes its JSON arguments into target.


### PR DESCRIPTION
Closes #106

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds policy-gated content capture (input/output) to tool observation spans, introduces fine-grained outcome classification, and migrates the tool span to use modern `gen_ai.*` / `langfuse.*` semantic attributes. The existing closure-based finish callback is replaced with a `toolObservation` struct backed by `sync.Once`, making panic finalization and normal finalization mutually exclusive without races.

- **`callObservedTool` / `toolObservation`**: the new struct owns the span lifecycle; `finishPanic` and `finish` both delegate to a `sync.Once`-guarded `setOutcome`, so a panic during a concurrent or re-entrant finish cannot double-end the span or lose attributes.
- **`toolResult`**: classifies outcomes into six low-cardinality strings (`success`, `tool_error`, `panic`, `deadline`, `cancellation`, `missing_response`) and maps them to fixed sentinel errors so raw tool errors and panic values are never exported to the span.
- **Content capture**: input is written to `tool.input` + aliases (`gen_ai.tool.call.arguments`, `langfuse.observation.input`); output is written to `tool.output` + `langfuse.observation.output`, with `gen_ai.tool.call.result` added only on success; the `missing_response` case correctly suppresses output capture entirely.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge; it touches only observability bookkeeping with no mutations to tool execution logic or public APIs.

The refactor is well-contained: callTool still returns the same ToolResponse to callers, the sync.Once prevents double-ending spans under any execution path, and the six-state outcome classifier correctly guards against emitting raw error or panic details. The test suite covers every outcome branch including the concurrent parent-span hierarchy check.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| loop/loop_obs.go | Major refactor of tool span lifecycle: replaces the old closure-based finish callback with a toolObservation struct using sync.Once for idempotent finalization; adds outcome classification, semantic gen_ai/langfuse attributes, policy-gated content aliases, and a panic-safe callObservedTool wrapper. |
| loop/tool.go | Splits the public CallTool into a thin wrapper over a new unexported callTool that returns a (response, missingResponse) pair so the observation layer can distinguish a tool returning nil from other error conditions. |
| loop/loop_obs_internal_test.go | Near-complete rewrite of the internal obs test suite: adds outcome coverage for all six states, panic re-panic verification, missing-response output suppression, policy-gated alias content, truncation, redaction, default-off capture, and a concurrency/parent-span test. |
| loop/loop.go | One-line call-site simplification: replaces the explicit startToolSpan / CallTool / finishToolSpan triple with a single callObservedTool call. |
| loop/loop_test.go | Extends the existing TestLoopCreatesToolSpans to assert the new gen_ai.operation.name / langfuse.observation.type semantic attributes and to verify the tool span is parented to a loop.iteration span. |
| README.md | Documents the new tool-span attributes, outcome values, content-capture API, and attribute aliases added by this PR; accurately reflects the implementation. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant ETC as executeToolCalls
    participant COT as callObservedTool
    participant STS as startToolSpan
    participant CT as callTool
    participant OBS as toolObservation

    ETC->>COT: callObservedTool(ctx, call, tools)
    COT->>STS: startToolSpan(ctx, call)
    STS-->>COT: toolCtx, observation
    COT->>CT: "callTool(toolCtx, &call, tools)"
    alt normal return
        CT-->>COT: response, missingResponse
        COT->>OBS: observation.finish(response, missingResponse)
        OBS->>OBS: toolResult() outcome/output/spanErr
        OBS->>OBS: CaptureContent if policy enabled
        OBS->>OBS: setOutcome SetAttributes + EndSpan
    else tool returns nil
        CT-->>COT: "NewToolError, missingResponse=true"
        COT->>OBS: "observation.finish(response, missingResponse=true)"
        OBS->>OBS: "outcome=missing_response, skip output capture"
        OBS->>OBS: setOutcome EndSpan with errObservedToolMissingResponse
    else panic
        CT--xCOT: panic(panicValue)
        COT->>OBS: observation.finishPanic()
        OBS->>OBS: setOutcome(panic, errObservedToolPanic)
        COT-->>ETC: panic(panicValue) re-thrown
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix missing\_response"](https://github.com/lace-ai/gai/commit/89c47db5dc44e7e4b5b46b9fa86996bcb8e425e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49326697)</sub>

<!-- /greptile_comment -->