### PR TITLE
fix(agent): canonicalize workflow output and expose tool events

### DIFF
--- a/agent/e2e_test.go
+++ b/agent/e2e_test.go
@@ -279,11 +279,17 @@ func TestAgentWorkflowStreamsRetriedAttemptTokens(t *testing.T) {
 		t.Fatalf("expected a discardable retry status, got %#v", consumed.statuses)
 	}
 	result := workflow.Result()
-	if got := result.Primary.Text; got != "partialfinal" {
-		t.Fatalf("unexpected primary result text: %q", got)
+	if got := result.Primary.Text; got != "final" {
+		t.Fatalf("unexpected canonical primary result text: %q", got)
 	}
-	if got := result.Text; got != "partialfinal" {
-		t.Fatalf("unexpected workflow result text: %q", got)
+	if got := result.Text; got != "final" {
+		t.Fatalf("unexpected canonical workflow result text: %q", got)
+	}
+	if got := result.Primary.AttemptedText; got != "partialfinal" {
+		t.Fatalf("unexpected primary diagnostic text: %q", got)
+	}
+	if got := result.AttemptedText; got != "partialfinal" {
+		t.Fatalf("unexpected workflow diagnostic text: %q", got)
 	}
 	if result.Usage != (ai.Usage{InputTokens: 6, OutputTokens: 5}) {
 		t.Fatalf("accepted usage = %#v", result.Usage)

--- a/agent/middleware.go
+++ b/agent/middleware.go
@@ -144,9 +144,8 @@ func (m *AgentMiddleware) Process(ctx context.Context, run *MiddlewareContext, u
 
 func (m *AgentMiddleware) upstreamResult(run *MiddlewareContext, captured capturedStream) WorkflowResult {
 	result := run.Result()
-	result.Tokens = cloneTokens(captured.Tokens)
-	result.Text = tokenText(captured.Tokens)
-	result.Reasoning = tokenReasoning(captured.Tokens)
+	result.AttemptedTokens = cloneTokens(captured.Tokens)
+	result.AttemptedText = tokenText(captured.Tokens)
 	result.Errors = append([]error(nil), captured.Errors...)
 	return result
 }
@@ -183,9 +182,8 @@ func (m *AgentMiddleware) runStage(ctx context.Context, input RunInput) AgentRes
 	tokens, statuses, errs := workflow.Run(ctx)
 	captured := drainStream(ctx, Stream{Tokens: tokens, Statuses: statuses, Errors: errs}, streamRelay{})
 	result := workflow.Result().Primary
-	result.Tokens = cloneTokens(captured.Tokens)
-	result.Text = tokenText(captured.Tokens)
-	result.Reasoning = tokenReasoning(captured.Tokens)
+	result.AttemptedTokens = cloneTokens(captured.Tokens)
+	result.AttemptedText = tokenText(captured.Tokens)
 	result.Errors = append([]error(nil), captured.Errors...)
 	return result
 }

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -32,17 +32,16 @@ type Stream struct {
 	Errors <-chan error
 }
 
-// AgentResult is the captured result of one agent execution. Text contains only
-// the concatenated text-token content, Reasoning contains thought-token content,
-// and Tokens retains the complete token stream. Because tokens are captured in
-// real time, a retried attempt's partial output remains present; use the ordered
-// loop Event stream when exact per-attempt rollback is required.
+// AgentResult contains canonical accepted output. AttemptedTokens and
+// AttemptedText retain the raw real-time stream, including discarded retries.
 type AgentResult struct {
-	Tokens     []ai.Token
-	Text       string
-	Reasoning  string
-	Messages   []gaictx.Message
-	Iterations []loop.Iteration
+	Tokens          []ai.Token
+	Text            string
+	Reasoning       string
+	AttemptedTokens []ai.Token
+	AttemptedText   string
+	Messages        []gaictx.Message
+	Iterations      []loop.Iteration
 	// Usage totals accepted iteration usage. BilledUsage includes discarded retries.
 	Usage       ai.Usage
 	BilledUsage ai.Usage
@@ -62,15 +61,16 @@ type StageResult struct {
 }
 
 // WorkflowResult is a snapshot of the complete workflow state. Primary never
-// changes, while Tokens, Text, and Reasoning represent the output after the
-// latest stage. These fields retain real-time partial output from retried
-// attempts; buffering to omit it would sacrifice real-time streaming.
+// changes, while Tokens, Text, and Reasoning represent canonical output after
+// the latest stage. AttemptedTokens and AttemptedText retain raw diagnostics.
 type WorkflowResult struct {
-	Input     RunInput
-	Primary   AgentResult
-	Tokens    []ai.Token
-	Text      string
-	Reasoning string
+	Input           RunInput
+	Primary         AgentResult
+	Tokens          []ai.Token
+	Text            string
+	Reasoning       string
+	AttemptedTokens []ai.Token
+	AttemptedText   string
 	// Usage totals accepted iteration usage. BilledUsage includes discarded retries.
 	Usage       ai.Usage
 	BilledUsage ai.Usage
@@ -302,9 +302,11 @@ func (w *Workflow) capturePrimary(ctx context.Context, upstream Stream, obs *wor
 	return captureStream(ctx, upstream, func(captured capturedStream) {
 		canceled, cancellationErr := captured.cancellation()
 		result := AgentResult{
-			Tokens:          cloneTokens(captured.Tokens),
-			Text:            tokenText(captured.Tokens),
-			Reasoning:       tokenReasoning(captured.Tokens),
+			Tokens:          iterationTokens(w.Loop.Iterations),
+			Text:            iterationText(w.Loop.Iterations),
+			Reasoning:       iterationReasoning(w.Loop.Iterations),
+			AttemptedTokens: cloneTokens(captured.Tokens),
+			AttemptedText:   tokenText(captured.Tokens),
 			Messages:        cloneMessages(w.Loop.Messages()),
 			Iterations:      cloneIterations(w.Loop.Iterations),
 			Usage:           iterationUsage(w.Loop.Iterations),
@@ -315,9 +317,11 @@ func (w *Workflow) capturePrimary(ctx context.Context, upstream Stream, obs *wor
 		}
 		w.mu.Lock()
 		w.result.Primary = result
-		w.result.Tokens = cloneTokens(captured.Tokens)
+		w.result.Tokens = cloneTokens(result.Tokens)
 		w.result.Text = result.Text
 		w.result.Reasoning = result.Reasoning
+		w.result.AttemptedTokens = cloneTokens(captured.Tokens)
+		w.result.AttemptedText = tokenText(captured.Tokens)
 		w.result.Usage = result.Usage
 		w.result.BilledUsage = result.BilledUsage
 		w.result.Errors = append([]error(nil), captured.Errors...)
@@ -332,9 +336,8 @@ func (w *Workflow) captureFinal(ctx context.Context, upstream Stream, obs *workf
 	return captureStream(ctx, upstream, func(captured capturedStream) {
 		canceled, cancellationErr := captured.cancellation()
 		w.mu.Lock()
-		w.result.Tokens = cloneTokens(captured.Tokens)
-		w.result.Text = tokenText(captured.Tokens)
-		w.result.Reasoning = tokenReasoning(captured.Tokens)
+		w.result.AttemptedTokens = cloneTokens(captured.Tokens)
+		w.result.AttemptedText = tokenText(captured.Tokens)
 		w.result.Errors = append([]error(nil), captured.Errors...)
 		if canceled {
 			w.result.Canceled = true
@@ -571,6 +574,31 @@ func tokenReasoning(tokens []ai.Token) string {
 	return string(reasoning)
 }
 
+func iterationTokens(iterations []loop.Iteration) []ai.Token {
+	var tokens []ai.Token
+	for _, iteration := range iterations {
+		for _, part := range iteration.Parts {
+			if part.Response != nil {
+				if part.Response.Reasoning != "" {
+					tokens = append(tokens, ai.Token{Type: ai.TokenTypeThought, Text: part.Response.Reasoning})
+				}
+				if part.Response.Text != "" {
+					tokens = append(tokens, ai.Token{Type: ai.TokenTypeText, Text: part.Response.Text})
+				}
+			}
+			if part.ToolReq != nil {
+				tokens = append(tokens, ai.Token{Type: ai.TokenTypeToolCall, ToolCall: cloneToolCall(part.ToolReq)})
+			}
+		}
+	}
+	return tokens
+}
+
+func iterationText(iterations []loop.Iteration) string { return tokenText(iterationTokens(iterations)) }
+func iterationReasoning(iterations []loop.Iteration) string {
+	return tokenReasoning(iterationTokens(iterations))
+}
+
 func cloneRunInput(input RunInput) RunInput {
 	cloned := input
 	if input.TraceContext != nil {
@@ -690,6 +718,7 @@ func cloneToolResponse(response *loop.ToolResponse) *loop.ToolResponse {
 
 func cloneAgentResult(result AgentResult) AgentResult {
 	result.Tokens = cloneTokens(result.Tokens)
+	result.AttemptedTokens = cloneTokens(result.AttemptedTokens)
 	result.Messages = cloneMessages(result.Messages)
 	result.Iterations = cloneIterations(result.Iterations)
 	result.Errors = append([]error(nil), result.Errors...)
@@ -705,6 +734,7 @@ func cloneWorkflowResult(result WorkflowResult) WorkflowResult {
 	result.Input = cloneRunInput(result.Input)
 	result.Primary = cloneAgentResult(result.Primary)
 	result.Tokens = cloneTokens(result.Tokens)
+	result.AttemptedTokens = cloneTokens(result.AttemptedTokens)
 	result.Errors = append([]error(nil), result.Errors...)
 	result.Stages = append([]StageResult(nil), result.Stages...)
 	for i := range result.Stages {

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -301,10 +301,11 @@ func (w *Workflow) Result() WorkflowResult {
 func (w *Workflow) capturePrimary(ctx context.Context, upstream Stream, obs *workflowObserver) Stream {
 	return captureStream(ctx, upstream, func(captured capturedStream) {
 		canceled, cancellationErr := captured.cancellation()
+		tokens := iterationTokens(w.Loop.Iterations)
 		result := AgentResult{
-			Tokens:          iterationTokens(w.Loop.Iterations),
-			Text:            iterationText(w.Loop.Iterations),
-			Reasoning:       iterationReasoning(w.Loop.Iterations),
+			Tokens:          tokens,
+			Text:            tokenText(tokens),
+			Reasoning:       tokenReasoning(tokens),
 			AttemptedTokens: cloneTokens(captured.Tokens),
 			AttemptedText:   tokenText(captured.Tokens),
 			Messages:        cloneMessages(w.Loop.Messages()),

--- a/loop/event.go
+++ b/loop/event.go
@@ -2,6 +2,7 @@ package loop
 
 import (
 	"context"
+	"time"
 
 	"github.com/lace-ai/gai/ai"
 )
@@ -18,6 +19,12 @@ const (
 	EventRetry EventType = "retry"
 	// EventIterationDone carries a completed agent iteration.
 	EventIterationDone EventType = "iteration_done"
+	// EventToolStart reports that a tool invocation has started.
+	EventToolStart EventType = "tool_start"
+	// EventToolResult reports a successful tool completion.
+	EventToolResult EventType = "tool_result"
+	// EventToolError reports a failed tool completion.
+	EventToolError EventType = "tool_error"
 	// EventDone reports successful loop completion.
 	EventDone EventType = "done"
 	// EventError reports terminal loop failure.
@@ -35,9 +42,12 @@ type Event struct {
 	RetryCount     int
 	PartCount      int
 
-	Token     *ai.Token
-	Iteration *Iteration
-	Err       error
+	Token        *ai.Token
+	Iteration    *Iteration
+	ToolCall     *ai.ToolCall
+	ToolResponse *ToolResponse
+	Duration     time.Duration
+	Err          error
 }
 
 func AttemptStartEvent(iteration, attempt, retry int) Event {
@@ -83,6 +93,19 @@ func IterationDoneEvent(iteration Iteration, attempt, retry int) Event {
 
 func DoneEvent() Event {
 	return Event{Type: EventDone}
+}
+
+func ToolStartEvent(iteration, attempt, retry int, call ai.ToolCall) Event {
+	return Event{Type: EventToolStart, IterationCount: iteration, AttemptID: attempt, RetryCount: retry, ToolCall: &call}
+}
+
+func ToolResultEvent(iteration, attempt, retry int, call ai.ToolCall, response *ToolResponse, duration time.Duration) Event {
+	eventType := EventToolResult
+	var err error
+	if response != nil && response.ErrorValue() != nil {
+		eventType, err = EventToolError, response.ErrorValue()
+	}
+	return Event{Type: eventType, IterationCount: iteration, AttemptID: attempt, RetryCount: retry, ToolCall: &call, ToolResponse: response, Duration: duration, Err: err}
 }
 
 func ErrorEvent(err error) Event {

--- a/loop/event.go
+++ b/loop/event.go
@@ -108,6 +108,10 @@ func ToolResultEvent(iteration, attempt, retry int, call ai.ToolCall, response *
 	return Event{Type: eventType, IterationCount: iteration, AttemptID: attempt, RetryCount: retry, ToolCall: &call, ToolResponse: response, Duration: duration, Err: err}
 }
 
+func ToolErrorEvent(iteration, attempt, retry int, call ai.ToolCall, response *ToolResponse, duration time.Duration, err error) Event {
+	return Event{Type: EventToolError, IterationCount: iteration, AttemptID: attempt, RetryCount: retry, ToolCall: &call, ToolResponse: response, Duration: duration, Err: err}
+}
+
 func ErrorEvent(err error) Event {
 	return Event{Type: EventError, Err: err}
 }

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -473,7 +473,13 @@ func (l *Loop) executeToolCalls(ctx context.Context, iteration *Iteration, toolC
 				}
 			}
 			if events != nil {
-				_ = sendEvent(ctx, events, ToolResultEvent(iterationCount, attemptID, retryCount, tc.call, toolRes, duration))
+				if err := sendEvent(ctx, events, ToolResultEvent(iterationCount, attemptID, retryCount, tc.call, toolRes, duration)); err != nil {
+					toolErrMu.Lock()
+					if toolErr == nil {
+						toolErr = err
+					}
+					toolErrMu.Unlock()
+				}
 			}
 		}(tc)
 	}

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -464,11 +464,21 @@ func (l *Loop) executeToolCalls(ctx context.Context, iteration *Iteration, toolC
 			iteration.Parts[tc.partIndex].ToolResp = toolRes
 			if l.ToolResponseProcessor != nil {
 				if err := l.ToolResponseProcessor.Process(tc.call, toolRes); err != nil {
+					processErr := fmt.Errorf("%w: %w", ErrToolResponseProcess, err)
 					toolErrMu.Lock()
 					if toolErr == nil {
-						toolErr = fmt.Errorf("%w: %w", ErrToolResponseProcess, err)
+						toolErr = processErr
 					}
 					toolErrMu.Unlock()
+					if events != nil {
+						if err := sendEvent(ctx, events, ToolErrorEvent(iterationCount, attemptID, retryCount, tc.call, toolRes, duration, processErr)); err != nil {
+							toolErrMu.Lock()
+							if toolErr == nil {
+								toolErr = err
+							}
+							toolErrMu.Unlock()
+						}
+					}
 					return
 				}
 			}

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/lace-ai/gai/ai"
 	gaictx "github.com/lace-ai/gai/context"
@@ -363,7 +364,7 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 				iterState.finish(nil)
 			}
 
-			if err := l.executeToolCalls(iterCtx, &iteration, toolCalls); err != nil {
+			if err := l.executeToolCalls(iterCtx, &iteration, toolCalls, events, iteration.Count, iterState.attemptID(), runState.retryCount); err != nil {
 				if cancelErr := cancellationError(iterCtx, err); cancelErr != nil {
 					sendAttemptCanceled(ctx, events, runState, iteration.Count, iterState.attemptID(), runState.retryCount, &iteration, cancelErr)
 					cancel()
@@ -442,17 +443,32 @@ func userMessageForIteration(promptBuilder gaictx.PromptBuilder, index int) *gai
 // executeToolCalls records tool responses on iteration. Tool execution
 // failures are stored in ToolResponse.Err and are not returned. Only framework
 // or tool-response processing failures are returned.
-func (l *Loop) executeToolCalls(ctx context.Context, iteration *Iteration, toolCalls []pendingToolCall) error {
+func (l *Loop) executeToolCalls(ctx context.Context, iteration *Iteration, toolCalls []pendingToolCall, eventArgs ...any) error {
+	var events chan<- Event
+	var iterationCount, attemptID, retryCount int
+	if len(eventArgs) == 4 {
+		events, _ = eventArgs[0].(chan<- Event)
+		iterationCount, _ = eventArgs[1].(int)
+		attemptID, _ = eventArgs[2].(int)
+		retryCount, _ = eventArgs[3].(int)
+	}
 	var wg sync.WaitGroup
 	var toolErr error
 	var toolErrMu sync.Mutex
 
 	for _, tc := range toolCalls {
+		if events != nil {
+			if err := sendEvent(ctx, events, ToolStartEvent(iterationCount, attemptID, retryCount, tc.call)); err != nil {
+				return err
+			}
+		}
 		wg.Add(1)
 		go func(tc pendingToolCall) {
 			defer wg.Done()
 
+			started := time.Now()
 			toolRes := callObservedTool(ctx, tc.call, l.Tools)
+			duration := time.Since(started)
 			iteration.Parts[tc.partIndex].ToolResp = toolRes
 			if l.ToolResponseProcessor != nil {
 				if err := l.ToolResponseProcessor.Process(tc.call, toolRes); err != nil {
@@ -463,6 +479,9 @@ func (l *Loop) executeToolCalls(ctx context.Context, iteration *Iteration, toolC
 					toolErrMu.Unlock()
 					return
 				}
+			}
+			if events != nil {
+				_ = sendEvent(ctx, events, ToolResultEvent(iterationCount, attemptID, retryCount, tc.call, toolRes, duration))
 			}
 		}(tc)
 	}

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -443,15 +443,7 @@ func userMessageForIteration(promptBuilder gaictx.PromptBuilder, index int) *gai
 // executeToolCalls records tool responses on iteration. Tool execution
 // failures are stored in ToolResponse.Err and are not returned. Only framework
 // or tool-response processing failures are returned.
-func (l *Loop) executeToolCalls(ctx context.Context, iteration *Iteration, toolCalls []pendingToolCall, eventArgs ...any) error {
-	var events chan<- Event
-	var iterationCount, attemptID, retryCount int
-	if len(eventArgs) == 4 {
-		events, _ = eventArgs[0].(chan<- Event)
-		iterationCount, _ = eventArgs[1].(int)
-		attemptID, _ = eventArgs[2].(int)
-		retryCount, _ = eventArgs[3].(int)
-	}
+func (l *Loop) executeToolCalls(ctx context.Context, iteration *Iteration, toolCalls []pendingToolCall, events chan<- Event, iterationCount, attemptID, retryCount int) error {
 	var wg sync.WaitGroup
 	var toolErr error
 	var toolErrMu sync.Mutex

--- a/loop/loop_obs_internal_test.go
+++ b/loop/loop_obs_internal_test.go
@@ -329,6 +329,40 @@ func TestExecuteToolCallsEmitsToolEvents(t *testing.T) {
 	}
 }
 
+func TestExecuteToolCallsReturnsCanceledWhenToolResultEventCannotBeSent(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	release := make(chan struct{})
+	tool := observedTestTool{name: "event", call: func(context.Context, *ai.ToolCall) *ToolResponse {
+		<-release
+		return NewToolSuccess("ok")
+	}}
+	l := &Loop{Tools: []Tool{tool}}
+	iteration := &Iteration{Parts: make([]IterationPart, 1)}
+	calls := []pendingToolCall{{
+		partIndex: 0,
+		call:      ai.ToolCall{ID: "call-event", Type: "function", Name: "event", Args: json.RawMessage(`{}`)},
+	}}
+	events := make(chan Event)
+	done := make(chan error, 1)
+	go func() { done <- l.executeToolCalls(ctx, iteration, calls, events, 3, 4, 5) }()
+
+	if event := <-events; event.Type != EventToolStart {
+		t.Fatalf("first tool event = %v, want %v", event.Type, EventToolStart)
+	}
+	close(release)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("executeToolCalls error = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("executeToolCalls did not return after context cancellation")
+	}
+}
+
 func requireToolSpans(t testing.TB, recorder *tracetest.SpanRecorder, count int) []sdktrace.ReadOnlySpan {
 	t.Helper()
 	spans := make([]sdktrace.ReadOnlySpan, 0, count)

--- a/loop/loop_obs_internal_test.go
+++ b/loop/loop_obs_internal_test.go
@@ -264,7 +264,7 @@ func TestExecuteToolCallsCreatesConcurrentChildSpans(t *testing.T) {
 	}
 	ctx, parent := otel.Tracer("test").Start(t.Context(), "loop.iteration")
 	done := make(chan error, 1)
-	go func() { done <- l.executeToolCalls(ctx, iteration, calls) }()
+	go func() { done <- l.executeToolCalls(ctx, iteration, calls, nil, 0, 0, 0) }()
 
 	seen := map[string]bool{}
 	for range calls {
@@ -291,6 +291,40 @@ func TestExecuteToolCallsCreatesConcurrentChildSpans(t *testing.T) {
 		}
 		if obstest.Attributes(span)["gai.tool.outcome"].AsString() != toolOutcomeSuccess {
 			t.Fatalf("tool span outcome = %#v", obstest.Attributes(span))
+		}
+	}
+}
+
+func TestExecuteToolCallsEmitsToolEvents(t *testing.T) {
+	tool := observedTestTool{name: "event", call: func(context.Context, *ai.ToolCall) *ToolResponse {
+		return NewToolSuccess("ok")
+	}}
+	l := &Loop{Tools: []Tool{tool}}
+	iteration := &Iteration{Parts: make([]IterationPart, 1)}
+	calls := []pendingToolCall{{
+		partIndex: 0,
+		call:      ai.ToolCall{ID: "call-event", Type: "function", Name: "event", Args: json.RawMessage(`{}`)},
+	}}
+	events := make(chan Event, 2)
+
+	if err := l.executeToolCalls(t.Context(), iteration, calls, events, 3, 4, 5); err != nil {
+		t.Fatalf("executeToolCalls error: %v", err)
+	}
+	close(events)
+
+	var got []Event
+	for event := range events {
+		got = append(got, event)
+	}
+	if len(got) != 2 {
+		t.Fatalf("tool events = %#v, want start and result", got)
+	}
+	if got[0].Type != EventToolStart || got[1].Type != EventToolResult {
+		t.Fatalf("tool event types = %v, %v; want %v, %v", got[0].Type, got[1].Type, EventToolStart, EventToolResult)
+	}
+	for _, event := range got {
+		if event.IterationCount != 3 || event.AttemptID != 4 || event.RetryCount != 5 || event.ToolCall == nil || event.ToolCall.ID != "call-event" {
+			t.Fatalf("tool event = %#v", event)
 		}
 	}
 }

--- a/loop/loop_obs_internal_test.go
+++ b/loop/loop_obs_internal_test.go
@@ -22,6 +22,12 @@ type observedTestTool struct {
 	call func(context.Context, *ai.ToolCall) *ToolResponse
 }
 
+type toolResponseProcessorFunc func(ai.ToolCall, *ToolResponse) error
+
+func (f toolResponseProcessorFunc) Process(call ai.ToolCall, response *ToolResponse) error {
+	return f(call, response)
+}
+
 func (t observedTestTool) Name() string              { return t.name }
 func (t observedTestTool) Description() string       { return "Test tool." }
 func (t observedTestTool) Params() ai.ToolParameters { return NewEchoTool().Params() }
@@ -326,6 +332,45 @@ func TestExecuteToolCallsEmitsToolEvents(t *testing.T) {
 		if event.IterationCount != 3 || event.AttemptID != 4 || event.RetryCount != 5 || event.ToolCall == nil || event.ToolCall.ID != "call-event" {
 			t.Fatalf("tool event = %#v", event)
 		}
+	}
+}
+
+func TestExecuteToolCallsEmitsToolErrorWhenResponseProcessingFails(t *testing.T) {
+	processorErr := errors.New("reject tool response")
+	tool := observedTestTool{name: "event", call: func(context.Context, *ai.ToolCall) *ToolResponse {
+		return NewToolSuccess("ok")
+	}}
+	l := &Loop{
+		Tools: []Tool{tool},
+		ToolResponseProcessor: toolResponseProcessorFunc(func(ai.ToolCall, *ToolResponse) error {
+			return processorErr
+		}),
+	}
+	iteration := &Iteration{Parts: make([]IterationPart, 1)}
+	calls := []pendingToolCall{{
+		partIndex: 0,
+		call:      ai.ToolCall{ID: "call-event", Type: "function", Name: "event", Args: json.RawMessage(`{}`)},
+	}}
+	events := make(chan Event, 2)
+
+	err := l.executeToolCalls(t.Context(), iteration, calls, events, 3, 4, 5)
+	if !errors.Is(err, ErrToolResponseProcess) || !errors.Is(err, processorErr) {
+		t.Fatalf("executeToolCalls error = %v, want wrapped processor error", err)
+	}
+	close(events)
+
+	got := make([]Event, 0, 2)
+	for event := range events {
+		got = append(got, event)
+	}
+	if len(got) != 2 {
+		t.Fatalf("tool events = %#v, want start and error", got)
+	}
+	if got[0].Type != EventToolStart || got[1].Type != EventToolError {
+		t.Fatalf("tool event types = %v, %v; want %v, %v", got[0].Type, got[1].Type, EventToolStart, EventToolError)
+	}
+	if got[1].ToolCall == nil || got[1].ToolCall.ID != "call-event" || !errors.Is(got[1].Err, processorErr) {
+		t.Fatalf("tool error event = %#v", got[1])
 	}
 }
 


### PR DESCRIPTION
Closes #76

## Summary
- keep canonical workflow and middleware input free of retry-discarded output while retaining raw attempted diagnostics
- add ordered tool start/result/error events with call IDs and durations
- preserve legacy streaming retry behavior

## Validation
- go test ./...
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lifecycle events for tool execution, including start, successful completion, failures, and duration.
  * Added tool call and response details to emitted events.
  * Added attempted output fields to distinguish accepted results from output generated during retries.

* **Bug Fixes**
  * Prevented discarded partial retry output from overwriting the final canonical result.
  * Preserved attempted text and tokens for diagnostics while keeping final results clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR canonicalizes `AgentResult` and `WorkflowResult` output by deriving `Tokens/Text/Reasoning` from accepted `loop.Iterations` (via `iterationTokens`) instead of the raw real-time stream, while preserving the raw stream in new `AttemptedTokens/AttemptedText` fields for diagnostics. It also fixes the silent tool-event feature by replacing the `eventArgs ...any` type-assertion pattern with a typed `chan<- Event` parameter and adds `ToolStart/Result/Error` lifecycle events with call IDs and durations.

- **Canonical output isolation**: `capturePrimary` now reads `w.Loop.Iterations` (accepted iterations only) for the canonical fields, so retry-discarded partial output no longer pollutes `Text/Tokens` passed into middleware or returned to callers.
- **Tool lifecycle events**: `executeToolCalls` emits a synchronous `ToolStartEvent` per call before launching goroutines, and each goroutine emits a `ToolResultEvent` or `ToolErrorEvent` (including for processor failures) with measured duration.
- **AttemptedTokens/Text**: both `AgentResult` and `WorkflowResult` gain these raw-stream fields, and `cloneAgentResult`/`cloneWorkflowResult` clone them correctly; the e2e test now asserts the clean/dirty split.

<h3>Confidence Score: 5/5</h3>

The change is safe to merge; all previously reported concurrency and type-assertion bugs are fixed, and the new canonical-output path is well-covered by updated tests.

The three previously flagged bugs (silent type-assertion failure, missing ToolErrorEvent on processor failure, and context-cancellation error being dropped) are all addressed. The new iterationTokens-based canonical path is correct: accepted iterations are finalized before capturePrimary's callback runs, so there is no race reading w.Loop.Iterations. The addStage path still updates canonical fields for middleware output. Remaining comments are minor style and design-quality observations with no runtime impact.

**Files Needing Attention:** No files require special attention, though the orphaned-goroutine edge case in loop/loop.go and the two unused helpers in agent/workflow.go are worth a quick look before the next iteration.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| loop/loop.go | Refactors executeToolCalls to take typed chan<-Event and int args instead of variadic any, and adds ToolStart/Result/Error event emission around each tool goroutine; fixes the silent type-assertion failure from the previous design. |
| loop/event.go | Adds EventToolStart/Result/Error constants and ToolStartEvent/ToolResultEvent/ToolErrorEvent constructors; ToolResultEvent auto-promotes to EventToolError when response.ErrorValue() != nil. |
| agent/workflow.go | Adds AttemptedTokens/AttemptedText to AgentResult and WorkflowResult; capturePrimary now derives canonical Tokens from iterationTokens(w.Loop.Iterations) to exclude retry-discarded output; captureFinal stores raw stream in AttemptedTokens only. |
| agent/middleware.go | Updates upstreamResult and runStage to populate AttemptedTokens/AttemptedText instead of overwriting canonical Tokens/Text/Reasoning, so middleware receives clean primary-loop text as input. |
| loop/loop_obs_internal_test.go | Adds three new tests for tool event emission: success path, processor-failure path, and context-cancellation-during-result-send path; updates existing test to pass nil events. |
| agent/e2e_test.go | Updates assertions to expect retry-discarded tokens in AttemptedText and only accepted output in canonical Text; error messages are clearer. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant L as Loop.Run
    participant E as events chan
    participant G as tool goroutine(s)
    participant C as captureStream callback

    L->>E: sendEvent(ToolStartEvent) [synchronous, per tool]
    L->>G: go callObservedTool()
    G->>G: execute tool, measure duration
    G->>G: ToolResponseProcessor.Process()
    alt processor fails
        G->>E: sendEvent(ToolErrorEvent)
        G-->>G: return early
    else tool or response has error
        G->>E: sendEvent(ToolResultEvent → EventToolError)
    else success
        G->>E: sendEvent(ToolResultEvent → EventToolResult)
    end
    L->>L: wg.Wait()

    L->>C: captureStream → capturePrimary callback
    C->>C: iterationTokens(w.Loop.Iterations) [canonical, no retries]
    C->>C: set Primary.Tokens, Text, Reasoning
    C->>C: set Primary.AttemptedTokens, AttemptedText [raw stream]

    L->>C: captureStream → captureFinal callback
    C->>C: set WorkflowResult.AttemptedTokens, AttemptedText
    C->>C: "Complete = true"
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(loop): emit tool error for processor..."](https://github.com/lace-ai/gai/commit/ebaa1b79b78fa4e3b02fec3881ed7438c75b28fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49500459)</sub>

<!-- /greptile_comment -->