### PR TITLE
fix(openai): return nil for unsupported tokenizer

### DIFF
--- a/ai/openai/model.go
+++ b/ai/openai/model.go
@@ -32,7 +32,9 @@ func (m *Model) NativeTools() bool { return true }
 
 func (m *Model) Close() error { return nil }
 
-func (m *Model) Tokenizer() ai.Tokenizer { return tokenizer{modelName: m.name} }
+// Tokenizer returns nil because OpenAI tokenization is not implemented by this provider.
+// This prevents callers from installing an unusable tokenizer into prompt or history flows.
+func (m *Model) Tokenizer() ai.Tokenizer { return nil }
 
 func (m *Model) Descriptor() ai.ModelDescriptor {
 	if facts, ok := m.provider.catalog.Lookup(m.name); ok {
@@ -490,18 +492,6 @@ func (m *Model) client(streaming bool) *sdk.Client {
 	}
 	client := sdk.NewClient(option.WithAPIKey(m.provider.apiKey), option.WithBaseURL(m.provider.baseURL), option.WithHTTPClient(httpClient), option.WithMaxRetries(0))
 	return &client
-}
-
-type tokenizer struct{ modelName string }
-
-func (t tokenizer) ID() string { return "openai." + t.modelName }
-
-func (tokenizer) CountTokens(context.Context, string) (int, error) {
-	return 0, ai.ErrTokenizerUnsupported
-}
-
-func (tokenizer) Tokenize(context.Context, string) ([]string, error) {
-	return nil, ai.ErrTokenizerUnsupported
 }
 
 func firstNonEmpty(values ...string) string {

--- a/ai/openai/model_test.go
+++ b/ai/openai/model_test.go
@@ -884,6 +884,13 @@ func TestOpenAIDescriptorUsesReasoningFamilyOverlay(t *testing.T) {
 	}
 }
 
+func TestModelTokenizerIsNilWhenTokenizationIsUnavailable(t *testing.T) {
+	m := &Model{name: GPT41}
+	if tokenizer := m.Tokenizer(); tokenizer != nil {
+		t.Fatalf("Tokenizer() = %T, want nil when tokenization is unavailable", tokenizer)
+	}
+}
+
 func TestModelDescriptorDoesNotAdvertiseUnsupportedTokenizer(t *testing.T) {
 	d := openAIDescriptor(GPT41)
 	if d.Tokenizer.Available != ai.FeatureSupportUnsupported || d.Tokenizer.Fidelity != ai.TokenizerFidelityUnknown {


### PR DESCRIPTION
Fixes #75.

OpenAI no longer returns a tokenizer that always fails tokenization operations. The provider now returns `nil`, so it cannot be auto-installed into prompt/history flows. A regression test locks in the unavailable-tokenizer contract.

Validation: `go test ./...`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed tokenizer implementation from OpenAI models; the model now returns no tokenizer.

* **Tests**
  * Added tests verifying tokenizer unavailability behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the stub `tokenizer` struct from the OpenAI provider and makes `Tokenizer()` return `nil` instead of a tokenizer that unconditionally fails with `ErrTokenizerUnsupported`. A regression test locks in this contract.

- All call sites in `agent/agent.go` and `context/prompt_builder.go` already guard against a `nil` tokenizer with explicit nil checks before installation into prompt/history flows, so this is a safe behavioral change.
- The pattern of returning `nil` from `Tokenizer()` is already established in the codebase (e.g., `legacyModel` in `ai/model_descriptor_test.go`), making this consistent with existing conventions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change removes dead code (a tokenizer that always returned errors) and returns nil instead, which every caller already handles with an explicit nil check.

The deleted tokenizer struct had no working behavior — it existed only to propagate ErrTokenizerUnsupported on every call. Returning nil is strictly better: callers in agent.go and prompt_builder.go already guard with `if tokenizer != nil` before installing it, so the runtime path is identical. The regression test is correct and tight, and the pattern of returning nil from Tokenizer() is already established by legacyModel elsewhere in the codebase.

**Files Needing Attention:** No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| ai/openai/model.go | Removes the stub tokenizer struct and its three always-failing methods; Tokenizer() now returns nil, which all known callers guard against. |
| ai/openai/model_test.go | Adds TestModelTokenizerIsNilWhenTokenizationIsUnavailable to lock in the nil-return contract; test is correct and the model struct is safely instantiated without a provider since Tokenizer() no longer touches any fields. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Agent
    participant OpenAIModel as OpenAI Model
    participant PromptBuilder

    Agent->>OpenAIModel: Tokenizer()
    note over OpenAIModel: Previously returned tokenizer{}<br/>that always errored
    OpenAIModel-->>Agent: nil (tokenization unavailable)

    Agent->>Agent: "if tokenizer != nil"
    note over Agent: nil check passes — tokenizer<br/>is NOT installed into prompt builder

    Agent->>PromptBuilder: New(loop) — no tokenizer set
    note over PromptBuilder: Skips token-counting,<br/>logs "tokenizer_missing"
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(openai): return nil for unsupported ..."](https://github.com/lace-ai/gai/commit/bc4d37f66e26a0b9436d25f3bb6d5766c4bf0294) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50093397)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/laceai/github/lace-ai/gai/-/custom-context?memory=173cdb2a-e8ea-489c-91ae-aa613f5b79be))

<!-- /greptile_comment -->