### PR TITLE
ci: add Go quality and compatibility gates

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,33 +1,124 @@
-# This workflow will build a golang project
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
-
 name: Go
 
-# This workflow only checks out and builds/tests the repository.
 permissions:
   contents: read
 
 on:
   push:
-    branches:
-      - "main"
+    branches: [main]
   pull_request:
-    branches:
-      - "main"
+    branches: [main]
+  schedule:
+    - cron: "17 3 * * 1"
+  workflow_dispatch:
 
 jobs:
-  build:
+  test:
+    name: Build, vet, and test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
-          go-version: "1.26.1"
-
+          go-version-file: go.mod
+          cache: true
+      - name: Vet
+        run: go vet ./...
       - name: Build
         run: go build -v ./...
-
       - name: Test
         run: go test -v ./...
+
+  race:
+    name: Race detector
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Test concurrency-sensitive packages with the race detector
+        run: go test -race ./agent ./ai/... ./context/... ./loop
+
+  staticcheck:
+    name: Staticcheck
+    runs-on: ubuntu-latest
+    env:
+      STATICCHECK_VERSION: v0.7.0
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION}
+      - name: Run staticcheck
+        run: staticcheck ./...
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Generate coverage report
+        run: go test -coverprofile=coverage.out ./...
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ github.sha }}
+          path: coverage.out
+          if-no-files-found: error
+
+  vulnerability-scan:
+    name: Dependency vulnerability scan
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      GOVULNCHECK_VERSION: v1.1.4
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@${GOVULNCHECK_VERSION}
+      - name: Scan dependencies for vulnerabilities
+        run: govulncheck ./...
+
+  api-compatibility:
+    name: Public API compatibility
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      APIDIFF_VERSION: v0.0.0-20260727155853-b88d891fe743
+      MODULE: github.com/lace-ai/gai
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+      - name: Install apidiff
+        run: go install golang.org/x/exp/cmd/apidiff@${APIDIFF_VERSION}
+      - name: Compare against the latest release
+        shell: bash
+        run: |
+          set -euo pipefail
+          baseline=$(git tag --list 'v*' --sort=-version:refname | head -n1)
+          test -n "$baseline"
+          git worktree add --detach ../gai-api-baseline "$baseline"
+          trap 'git worktree remove --force ../gai-api-baseline' EXIT
+          (
+            cd ../gai-api-baseline
+            apidiff -m -w ../gai-api-baseline.json "$MODULE"
+          )
+          apidiff -m ../gai-api-baseline.json "$MODULE"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,8 +17,8 @@ jobs:
     name: Build, vet, and test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: go.mod
           cache: true
@@ -33,8 +33,8 @@ jobs:
     name: Race detector
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: go.mod
           cache: true
@@ -47,8 +47,8 @@ jobs:
     env:
       STATICCHECK_VERSION: v0.7.0
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: go.mod
           cache: true
@@ -61,15 +61,15 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: go.mod
           cache: true
       - name: Generate coverage report
         run: go test -coverprofile=coverage.out ./...
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: coverage-${{ github.sha }}
           path: coverage.out
@@ -82,8 +82,8 @@ jobs:
     env:
       GOVULNCHECK_VERSION: v1.1.4
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: go.mod
           cache: true
@@ -100,10 +100,10 @@ jobs:
       APIDIFF_VERSION: v0.0.0-20260727155853-b88d891fe743
       MODULE: github.com/lace-ai/gai
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: go.mod
@@ -34,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: go.mod
@@ -48,6 +52,8 @@ jobs:
       STATICCHECK_VERSION: v0.7.0
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: go.mod
@@ -62,6 +68,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: go.mod
@@ -83,6 +91,8 @@ jobs:
       GOVULNCHECK_VERSION: v1.1.4
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: go.mod
@@ -103,6 +113,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version-file: go.mod

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
-      - name: Test concurrency-sensitive packages with the race detector
-        run: go test -race ./agent ./ai/... ./context/... ./loop
+      - name: Test all packages with the race detector
+        run: go test -race ./...
 
   staticcheck:
     name: Staticcheck

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -88,7 +88,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     env:
-      GOVULNCHECK_VERSION: v1.1.4
+      GOVULNCHECK_VERSION: v1.6.0
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:

--- a/README.md
+++ b/README.md
@@ -490,6 +490,8 @@ go test ./loop/...
 go test ./examples/order-support
 ```
 
+GitHub Actions runs build, vet, tests, race detection for concurrency-sensitive packages, static analysis, coverage artifact generation, and public API compatibility checks on pull requests. Dependency vulnerability scanning runs weekly on Mondays at 03:17 UTC and can also be started manually from the Actions tab.
+
 ## Contributing
 
 Issues and pull requests are welcome. For a new provider or tool, include tests and document its constructor, supported behavior, and required environment variables.

--- a/README.md
+++ b/README.md
@@ -503,3 +503,4 @@ Before making a large API change, open an issue describing the use case and comp
 GAI is available under the [MIT License](LICENSE).
 
 Copyright (c) 2026 Samuel Konrad.
+


### PR DESCRIPTION
Closes #90

Adds separate build/vet/test, race, staticcheck, coverage artifact, scheduled/manual vulnerability scan, and API-compatibility jobs. Tool versions are pinned; the README documents the weekly scan cadence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded automated checks for builds, tests, race detection, static analysis, code coverage, and API compatibility.
  * Added validation for pushes and pull requests, along with scheduled and manual vulnerability scans.
  * Enabled coverage reports as downloadable build artifacts.
  * Added automated comparisons with the latest tagged release to identify API compatibility changes.

* **Documentation**
  * Updated the README with details about the available continuous integration checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR expands Go CI quality and compatibility checks and documents their operation.
- Adds build, vet, full test, race-detector, staticcheck, coverage, vulnerability-scan, and API-compatibility jobs.
- Pins GitHub Actions dependencies to immutable commit SHAs and disables persisted checkout credentials.
- Documents the weekly and manually triggered vulnerability scans.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/go.yml | Adds comprehensive Go CI gates; the previously reported race scope and action pinning concerns are addressed, and the API baseline resolves from the repository's existing tags. |
| README.md | Documents the added CI checks and vulnerability-scan schedule consistently with the workflow. |

</details>

<sub>Reviews (5): Last reviewed commit: ["ci: update govulncheck"](https://github.com/lace-ai/gai/commit/77035ec19e3f427811bbda07435045846582cd72) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50869542)</sub>

<!-- /greptile_comment -->