### PR TITLE
fix: resolve staticcheck findings

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -202,7 +202,7 @@ func usesNativeTools(model ai.Model) bool {
 	if describer, ok := model.(ai.ModelDescriber); ok {
 		return describer.Descriptor().SupportsNativeTools()
 	}
-	native, ok := model.(ai.NativeToolModel)
+	native, ok := model.(interface{ NativeTools() bool })
 	return ok && native.NativeTools()
 }
 

--- a/agent/obs.go
+++ b/agent/obs.go
@@ -196,7 +196,7 @@ func (o *workflowObserver) Finished(ctx context.Context, result WorkflowResult) 
 		"error_count":      len(result.Errors),
 		"complete":         result.Complete,
 	}
-	if o != nil && o.span != nil {
+	if o.span != nil {
 		o.span.SetAttributes(
 			attribute.Int("agent.stage_count", len(result.Stages)),
 			attribute.Int("agent.token_count", len(result.Tokens)),
@@ -208,7 +208,7 @@ func (o *workflowObserver) Finished(ctx context.Context, result WorkflowResult) 
 	gai.AddDebugContent(ctx, o.debug, fields, "reasoning", gai.ContentKindReasoning, result.Reasoning)
 	err := errors.Join(result.Errors...)
 	o.emit(ctx, "agent_workflow_finished", fields, err)
-	if o != nil && o.span != nil {
+	if o.span != nil {
 		gai.EndSpan(o.span, err)
 	}
 }
@@ -270,12 +270,15 @@ func (o *middlewareObserver) Skipped(ctx context.Context, reason string) {
 }
 
 func (o *middlewareObserver) Finished(ctx context.Context, result AgentResult, applied bool) {
+	if o == nil {
+		return
+	}
 	fields := o.fields()
 	for key, value := range agentResultFields(result) {
 		fields[key] = value
 	}
 	fields["output_applied"] = applied
-	if o != nil && o.span != nil {
+	if o.span != nil {
 		o.span.SetAttributes(
 			attribute.Int("agent.middleware.token_count", len(result.Tokens)),
 			attribute.Int("agent.middleware.error_count", len(result.Errors)),
@@ -290,7 +293,7 @@ func (o *middlewareObserver) Finished(ctx context.Context, result AgentResult, a
 		name = "agent_middleware_failed"
 	}
 	o.emit(ctx, name, fields, err)
-	if o != nil && o.span != nil {
+	if o.span != nil {
 		gai.EndSpan(o.span, err)
 	}
 }

--- a/agent/summary/summary_test.go
+++ b/agent/summary/summary_test.go
@@ -86,34 +86,3 @@ func (m *recordingModel) Close() error {
 func (m *recordingModel) Tokenizer() ai.Tokenizer {
 	return &mocks.MockTokenizer{}
 }
-
-type toolCallModel struct {
-	tokens []ai.Token
-}
-
-func (m toolCallModel) Name() string {
-	return "tool-call"
-}
-
-func (m toolCallModel) Generate(context.Context, ai.AIRequest) (*ai.AIResponse, error) {
-	return &ai.AIResponse{}, nil
-}
-
-func (m toolCallModel) GenerateStream(context.Context, ai.AIRequest) <-chan ai.Token {
-	out := make(chan ai.Token, len(m.tokens))
-	go func() {
-		defer close(out)
-		for _, token := range m.tokens {
-			out <- token
-		}
-	}()
-	return out
-}
-
-func (m toolCallModel) Close() error {
-	return nil
-}
-
-func (m toolCallModel) Tokenizer() ai.Tokenizer {
-	return &mocks.MockTokenizer{}
-}

--- a/agent/workflow.go
+++ b/agent/workflow.go
@@ -595,11 +595,6 @@ func iterationTokens(iterations []loop.Iteration) []ai.Token {
 	return tokens
 }
 
-func iterationText(iterations []loop.Iteration) string { return tokenText(iterationTokens(iterations)) }
-func iterationReasoning(iterations []loop.Iteration) string {
-	return tokenReasoning(iterationTokens(iterations))
-}
-
 func cloneRunInput(input RunInput) RunInput {
 	cloned := input
 	if input.TraceContext != nil {

--- a/ai/anthropic/model.go
+++ b/ai/anthropic/model.go
@@ -29,7 +29,6 @@ type Model struct {
 
 var _ ai.Model = (*Model)(nil)
 var _ ai.ModelDescriber = (*Model)(nil)
-var _ ai.NativeToolModel = (*Model)(nil)
 
 func (m *Model) Name() string      { return m.name }
 func (m *Model) NativeTools() bool { return true }

--- a/ai/gemini/model.go
+++ b/ai/gemini/model.go
@@ -27,7 +27,6 @@ type Model struct {
 
 var _ ai.Model = (*Model)(nil)
 var _ ai.ModelDescriber = (*Model)(nil)
-var _ ai.NativeToolModel = (*Model)(nil)
 
 func (m *Model) Name() string {
 	return m.name
@@ -709,7 +708,7 @@ func (t *Tokenizer) ID() string {
 }
 
 func (t *Tokenizer) CountTokens(ctx context.Context, text string) (tokens int, err error) {
-	ctx, span := gai.StartOperationSpan(ctx, geminiTracerName, "ai.gemini", "ai.operation", "tokenizer.count_tokens",
+	_, span := gai.StartOperationSpan(ctx, geminiTracerName, "ai.gemini", "ai.operation", "tokenizer.count_tokens",
 		attribute.String("ai.provider", "gemini"),
 		attribute.String("ai.model", t.modelName),
 		attribute.String("ai.tokenizer", t.ID()),
@@ -733,7 +732,7 @@ func (t *Tokenizer) CountTokens(ctx context.Context, text string) (tokens int, e
 }
 
 func (t *Tokenizer) Tokenize(ctx context.Context, text string) (tokens []string, err error) {
-	ctx, span := gai.StartOperationSpan(ctx, geminiTracerName, "ai.gemini", "ai.operation", "tokenizer.tokenize",
+	_, span := gai.StartOperationSpan(ctx, geminiTracerName, "ai.gemini", "ai.operation", "tokenizer.tokenize",
 		attribute.String("ai.provider", "gemini"),
 		attribute.String("ai.model", t.modelName),
 		attribute.String("ai.tokenizer", t.ID()),

--- a/ai/gemini/provider.go
+++ b/ai/gemini/provider.go
@@ -184,12 +184,6 @@ func (p *Provider) getClient(ctx context.Context) (*genai.Client, error) {
 	})
 }
 
-func fallbackModels() []string {
-	out := make([]string, len(models))
-	copy(out, models)
-	return out
-}
-
 func containsModel(models []string, name string) bool {
 	for _, modelName := range models {
 		if modelName == name {

--- a/ai/generation_observation_test.go
+++ b/ai/generation_observation_test.go
@@ -19,7 +19,7 @@ func TestGenerationObservationRecordsSemanticContract(t *testing.T) {
 	defer restore()
 
 	ctx, parent := otel.Tracer("test").Start(context.Background(), "parent")
-	ctx, observation := StartGenerationObservation(ctx, AIRequest{
+	_, observation := StartGenerationObservation(ctx, AIRequest{
 		Prompt: "private prompt", MaxTokens: 42,
 		ResponseFormat: ResponseFormat{Type: ResponseFormatJSONSchema},
 	}, GenerationConfig{Provider: "test-provider", Model: "requested-model", Streaming: true})
@@ -67,7 +67,7 @@ func TestGenerationObservationRecordsSemanticContract(t *testing.T) {
 		t.Fatalf("span kind = %s, want client", span.SpanKind())
 	}
 	for key, value := range attrs {
-		if strings.Contains(value.Emit(), "private prompt") || strings.Contains(value.Emit(), "private completion") {
+		if strings.Contains(value.String(), "private prompt") || strings.Contains(value.String(), "private completion") {
 			t.Fatalf("content leaked through %s", key)
 		}
 	}

--- a/ai/mistral/model.go
+++ b/ai/mistral/model.go
@@ -26,7 +26,6 @@ type Model struct {
 
 var _ ai.Model = (*Model)(nil)
 var _ ai.ModelDescriber = (*Model)(nil)
-var _ ai.NativeToolModel = (*Model)(nil)
 
 func (m *Model) Name() string {
 	return m.name

--- a/ai/mistral/provider.go
+++ b/ai/mistral/provider.go
@@ -156,12 +156,6 @@ func (p *Provider) listModelCatalog(ctx context.Context) ([]ai.ModelDescriptor, 
 	return descriptors, nil
 }
 
-func fallbackModels() []string {
-	out := make([]string, len(models))
-	copy(out, models)
-	return out
-}
-
 func (p *Provider) fallbackDescriptors() []ai.ModelDescriptor {
 	descriptors := make([]ai.ModelDescriptor, 0, len(models))
 	for _, model := range models {

--- a/ai/openai/model.go
+++ b/ai/openai/model.go
@@ -24,7 +24,6 @@ type Model struct {
 
 var _ ai.Model = (*Model)(nil)
 var _ ai.ModelDescriber = (*Model)(nil)
-var _ ai.NativeToolModel = (*Model)(nil)
 
 func (m *Model) Name() string { return m.name }
 

--- a/ai/openai/provider.go
+++ b/ai/openai/provider.go
@@ -194,12 +194,6 @@ func isChatCapableModel(name string) bool {
 	return name != "gpt-5.6-auto"
 }
 
-func fallbackModels() []string {
-	out := make([]string, len(models))
-	copy(out, models)
-	return out
-}
-
 func (p *Provider) fallbackDescriptors() []ai.ModelDescriptor {
 	descriptors := make([]ai.ModelDescriptor, 0, len(models))
 	for _, model := range models {

--- a/context/history/obs.go
+++ b/context/history/obs.go
@@ -295,7 +295,9 @@ func (o *historyObserver) BuildFinished(ctx context.Context, part *Part, tokenCo
 	o.turnCount = turnCount
 	o.includedTurnCount = includedTurnCount
 	o.messageCount = messageCount
-	o.contentCount = len(part.Contents)
+	if part != nil {
+		o.contentCount = len(part.Contents)
+	}
 
 	fields := map[string]any{
 		"session_id":    o.sessionID,

--- a/context/history/obs_test.go
+++ b/context/history/obs_test.go
@@ -1,0 +1,17 @@
+package history
+
+import (
+	"context"
+	"testing"
+)
+
+func TestHistoryObserverBuildFinishedAcceptsNilPart(t *testing.T) {
+	t.Parallel()
+
+	observer := &historyObserver{}
+	observer.BuildFinished(context.Background(), nil, 0, 0, 0, 0)
+
+	if observer.contentCount != 0 {
+		t.Fatalf("content count = %d, want 0", observer.contentCount)
+	}
+}

--- a/loop/loop_obs_internal_test.go
+++ b/loop/loop_obs_internal_test.go
@@ -427,13 +427,13 @@ func toolSpanText(span sdktrace.ReadOnlySpan) string {
 	text.WriteString(span.Status().Description)
 	for _, attr := range span.Attributes() {
 		text.WriteString(string(attr.Key))
-		text.WriteString(attr.Value.Emit())
+		text.WriteString(attr.Value.String())
 	}
 	for _, event := range span.Events() {
 		text.WriteString(event.Name)
 		for _, attr := range event.Attributes {
 			text.WriteString(string(attr.Key))
-			text.WriteString(attr.Value.Emit())
+			text.WriteString(attr.Value.String())
 		}
 	}
 	return text.String()

--- a/loop/tool.go
+++ b/loop/tool.go
@@ -1,7 +1,6 @@
 package loop
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -140,17 +139,6 @@ func ToolCallToString(tc ai.ToolCall) string {
 	builder.WriteString(",arguments: ")
 	builder.Write(tc.Args)
 	return builder.String()
-}
-
-func toolCallSignature(tc ai.ToolCall) string {
-	args := strings.TrimSpace(string(tc.Args))
-	if len(tc.Args) > 0 {
-		var compact bytes.Buffer
-		if err := json.Compact(&compact, tc.Args); err == nil {
-			args = compact.String()
-		}
-	}
-	return tc.Name + "\x00" + args
 }
 
 // String returns the response text.

--- a/loop/tools/exa/obs.go
+++ b/loop/tools/exa/obs.go
@@ -12,7 +12,7 @@ import (
 
 const exaTracerName = "github.com/lace-ai/gai/loop/tools/exa"
 
-var errObservedExaSearch = errors.New("Exa search failed")
+var errObservedExaSearch = errors.New("exa search failed")
 
 type searchObserver struct {
 	debug      gai.DebugSink

--- a/loop/tools/exa/search.go
+++ b/loop/tools/exa/search.go
@@ -233,7 +233,7 @@ func (t *SearchTool) Function(ctx context.Context, call *ai.ToolCall) (response 
 	ctx, observer := newSearchObserver(ctx, t.debug, t.searchType, t.numResults)
 	defer func() {
 		if response == nil {
-			observer.Finish(errors.New("Exa search returned no tool response"))
+			observer.Finish(errors.New("exa search returned no tool response"))
 			return
 		}
 		observer.Finish(response.ErrorValue())


### PR DESCRIPTION
Resolves #125.

- remove obsolete and unused internal code
- retain legacy native-tool behavior without depending on the deprecated public interface
- make observer handling nil-safe and cover nil history parts
- update deprecated OpenTelemetry test APIs

Validation:
- staticcheck ./...
- go test ./...
- go build ./...
- apidiff against v0.6.1

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR resolves staticcheck findings while preserving legacy native-tool detection and improving nil safety in observation code.
- Replaces reliance on the deprecated native-tool interface with an equivalent structural capability check.
- Makes middleware and history observation handling nil-safe.
- Removes unused helpers and obsolete compile-time interface assertions.
- Updates OpenTelemetry tests and error strings to current API and lint conventions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable correctness, security, or compatibility defects identified.

The behavioral changes preserve native-tool transport selection, safely handle nil observers and history parts, and remove or modernize code without affecting reachable runtime contracts.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| agent/agent.go | Preserves descriptor-first native-tool detection while replacing the deprecated named-interface assertion with its equivalent method set. |
| agent/obs.go | Adds an early nil guard for middleware completion and simplifies subsequent span checks safely. |
| ai/gemini/model.go | Discards unused span contexts in local tokenizer operations that perform no downstream context-aware calls. |
| context/history/obs.go | Prevents dereferencing a nil history part while retaining correct behavior for the production non-nil path. |
| loop/tools/exa/search.go | Adjusts a locally created error string to staticcheck-compatible capitalization without changing control flow. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: resolve staticcheck findings"](https://github.com/lace-ai/gai/commit/b02e379d76e9bb7a42549ea283df37c9091d2e0f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51128123)</sub>

<!-- /greptile_comment -->