### PR TITLE
feat(loop): add classified retry policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,27 @@ for event := range workflow.RunEvents(ctx) {
 
 `Workflow.Run` remains available for workflows that use post-processing middleware. It exposes compatibility token, status, and error channels; consumers must drain all three concurrently.
 
+## Retries
+
+Retries are opt-in. A loop or agent with no `RetryPolicy` performs one model-generation attempt and returns the original error; it never emits a retry event. Configure an explicit policy when classified transient failures, rate limits, or attempt timeouts should retry:
+
+```go
+policy := &loop.RetryPolicy{
+  MaxRetries:     3,
+  InitialBackoff: time.Second,
+  MaxBackoff:     10 * time.Second,
+}
+
+support := agent.New(agent.Definition{
+  Name:        "support",
+  Model:       model,
+  Prompt:      supportPrompt,
+  RetryPolicy: policy,
+})
+```
+
+`Loop.RetryCount`, `agent.Limits.RetryCount`, and `summary.WithRetryCount` were removed while GAI is pre-v1. Migrate to `loop.RetryPolicy{MaxRetries: n}` or `summary.WithRetryPolicy(loop.RetryPolicy{MaxRetries: n})`. Runtime event retry counters remain available for observability.
+
 ## Prompt and context construction
 
 The `context` package builds prompts from separate, typed inputs:

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -58,6 +58,9 @@ type Definition struct {
 	Prompt Prompt
 	// Limits configures loop execution defaults.
 	Limits Limits
+	// RetryPolicy enables classified model-generation retries. Nil disables retries.
+	// Each workflow receives its own copy of the configured policy.
+	RetryPolicy *loop.RetryPolicy
 	// Reasoning configures model reasoning/thinking behavior for every model call.
 	Reasoning ai.ReasoningConfig
 	// Tokenizer overrides Model.Tokenizer when it is non-nil.
@@ -190,6 +193,10 @@ func (a *Agent) newLoop(ctx context.Context, input RunInput) (*loop.Loop, error)
 	}
 	l.ResponseFormat = cloneResponseFormat(input.ResponseFormat)
 	l.Reasoning = a.def.Reasoning
+	if a.def.RetryPolicy != nil {
+		policy := *a.def.RetryPolicy
+		l.RetryPolicy = &policy
+	}
 	return l, nil
 }
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -29,12 +29,10 @@ type RunInput struct {
 // Prompt creates the prompt builder used by one run.
 type Prompt func(ctx context.Context, input RunInput) (gaictx.PromptBuilder, error)
 
-// Limits controls loop retries, iterations, and model output size.
+// Limits controls loop iterations and model output size.
 type Limits struct {
 	// MaxLoopIterations limits model/tool iterations. Zero uses the loop default.
 	MaxLoopIterations int
-	// RetryCount limits model retries. Zero uses the loop default.
-	RetryCount int
 	// MaxTokens is the default model output limit for the agent.
 	MaxTokens int
 }
@@ -184,9 +182,6 @@ func (a *Agent) newLoop(ctx context.Context, input RunInput) (*loop.Loop, error)
 	}
 	if a.def.Limits.MaxLoopIterations > 0 {
 		l.MaxLoopIterations = a.def.Limits.MaxLoopIterations
-	}
-	if a.def.Limits.RetryCount > 0 {
-		l.RetryCount = a.def.Limits.RetryCount
 	}
 	if input.MaxTokens > 0 {
 		l.MaxTokens = input.MaxTokens

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -124,7 +124,6 @@ func TestAgentNewRunCreatesLoop(t *testing.T) {
 		},
 		Limits: agent.Limits{
 			MaxLoopIterations: 2,
-			RetryCount:        1,
 			MaxTokens:         9,
 		},
 		Reasoning: ai.ReasoningConfig{
@@ -147,9 +146,6 @@ func TestAgentNewRunCreatesLoop(t *testing.T) {
 	}
 	if run.Loop.MaxLoopIterations != 2 {
 		t.Fatalf("expected max iterations 2, got %d", run.Loop.MaxLoopIterations)
-	}
-	if run.Loop.RetryCount != 1 {
-		t.Fatalf("expected retry count 1, got %d", run.Loop.RetryCount)
 	}
 	if run.Loop.MaxTokens != 9 {
 		t.Fatalf("expected max tokens 9, got %d", run.Loop.MaxTokens)

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/lace-ai/gai/agent"
 	"github.com/lace-ai/gai/ai"
@@ -155,6 +156,34 @@ func TestAgentNewRunCreatesLoop(t *testing.T) {
 	}
 	if builder == nil || builder.tokenizer == nil {
 		t.Fatal("expected model tokenizer to be set on prompt builder")
+	}
+}
+
+func TestAgentNewRunCopiesRetryPolicy(t *testing.T) {
+	t.Parallel()
+
+	policy := &loop.RetryPolicy{MaxRetries: 2, InitialBackoff: time.Second}
+	assistant := agent.New(agent.Definition{
+		Model:       &mocks.MockModel{},
+		RetryPolicy: policy,
+		Prompt: func(context.Context, agent.RunInput) (gaictx.PromptBuilder, error) {
+			return &testPromptBuilder{}, nil
+		},
+	})
+
+	first, err := assistant.NewRun(context.Background(), textRunInput("first"))
+	if err != nil {
+		t.Fatalf("first NewRun failed: %v", err)
+	}
+	second, err := assistant.NewRun(context.Background(), textRunInput("second"))
+	if err != nil {
+		t.Fatalf("second NewRun failed: %v", err)
+	}
+	if first.Loop.RetryPolicy == nil || first.Loop.RetryPolicy.MaxRetries != policy.MaxRetries || first.Loop.RetryPolicy.InitialBackoff != policy.InitialBackoff {
+		t.Fatalf("first retry policy = %#v, want %#v", first.Loop.RetryPolicy, policy)
+	}
+	if first.Loop.RetryPolicy == policy || second.Loop.RetryPolicy == policy || first.Loop.RetryPolicy == second.Loop.RetryPolicy {
+		t.Fatal("each workflow must receive an independent retry policy copy")
 	}
 }
 

--- a/agent/e2e_test.go
+++ b/agent/e2e_test.go
@@ -187,11 +187,12 @@ func TestAgentWorkflowEndToEndWithToolCall(t *testing.T) {
 }
 
 func TestAgentWorkflowMarksTerminalFailedAttemptDiscardable(t *testing.T) {
+	fatalErr := errors.New("fatal stream error")
 	model := &scriptedWorkflowModel{
 		scripts: [][]ai.Token{
 			{
 				{Type: ai.TokenTypeText, Text: "partial"},
-				{Err: errors.New("fatal stream error")},
+				{Err: fatalErr},
 			},
 		},
 	}
@@ -216,8 +217,8 @@ func TestAgentWorkflowMarksTerminalFailedAttemptDiscardable(t *testing.T) {
 	if len(consumed.errs) != 1 {
 		t.Fatalf("expected one workflow error, got %d", len(consumed.errs))
 	}
-	if !errors.Is(consumed.errs[0], loop.ErrMaxRetries) {
-		t.Fatalf("error = %v, want ErrMaxRetries", consumed.errs[0])
+	if !errors.Is(consumed.errs[0], fatalErr) || errors.Is(consumed.errs[0], loop.ErrMaxRetries) {
+		t.Fatalf("error = %v, want original non-retry error", consumed.errs[0])
 	}
 	if got := tokensText(consumed.tokens); got != "partial" {
 		t.Fatalf("expected partial token to stream before failure, got %q", got)

--- a/agent/e2e_test.go
+++ b/agent/e2e_test.go
@@ -212,7 +212,6 @@ func TestAgentWorkflowMarksTerminalFailedAttemptDiscardable(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRun failed: %v", err)
 	}
-	workflow.Loop.RetryCount = 0
 	consumed := consumeWorkflow(t, workflow)
 	if len(consumed.errs) != 1 {
 		t.Fatalf("expected one workflow error, got %d", len(consumed.errs))
@@ -245,7 +244,7 @@ func TestAgentWorkflowStreamsRetriedAttemptTokens(t *testing.T) {
 				{Type: ai.TokenTypeText, Text: "partial"},
 				{Type: ai.TokenTypeCompletion, Completion: &ai.Completion{Usage: ai.Usage{InputTokens: 3, OutputTokens: 2}}},
 				{Type: ai.TokenTypeCompletion, Completion: &ai.Completion{Usage: ai.Usage{InputTokens: 4, OutputTokens: 3}}},
-				{Err: errors.New("retriable stream error")},
+				{Err: &ai.ProviderError{Kind: ai.ProviderErrorTransient, Err: errors.New("retriable stream error")}},
 			},
 			{
 				{Type: ai.TokenTypeText, Text: "final"},
@@ -267,7 +266,7 @@ func TestAgentWorkflowStreamsRetriedAttemptTokens(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRun failed: %v", err)
 	}
-	workflow.Loop.RetryCount = 1
+	workflow.Loop.RetryPolicy = &loop.RetryPolicy{MaxRetries: 1}
 	consumed := consumeWorkflow(t, workflow)
 	if len(consumed.errs) != 0 {
 		t.Fatalf("unexpected workflow errors: %v", consumed.errs)
@@ -386,7 +385,7 @@ func TestAgentWorkflowRunEventsPreservesRetryOrdering(t *testing.T) {
 		scripts: [][]ai.Token{
 			{
 				{Type: ai.TokenTypeText, Text: "partial"},
-				{Err: errors.New("retriable stream error")},
+				{Err: &ai.ProviderError{Kind: ai.ProviderErrorTransient, Err: errors.New("retriable stream error")}},
 			},
 			{{Type: ai.TokenTypeText, Text: "final"}},
 		},
@@ -404,7 +403,7 @@ func TestAgentWorkflowRunEventsPreservesRetryOrdering(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRun failed: %v", err)
 	}
-	workflow.Loop.RetryCount = 1
+	workflow.Loop.RetryPolicy = &loop.RetryPolicy{MaxRetries: 1}
 
 	var events []loop.Event
 	for event := range workflow.RunEvents(context.Background()) {

--- a/agent/obs_test.go
+++ b/agent/obs_test.go
@@ -288,7 +288,7 @@ func TestTraceContextPropagatesAcrossRetriesToolsAndNestedMiddleware(t *testing.
 	})
 
 	primaryModel := &traceTestModel{scripts: [][]ai.Token{
-		{{Type: ai.TokenTypeErr, Err: errors.New("retry")}},
+		{{Type: ai.TokenTypeErr, Err: &ai.ProviderError{Kind: ai.ProviderErrorTransient, Err: errors.New("retry")}}},
 		{{Type: ai.TokenTypeToolCall, ToolCall: &ai.ToolCall{ID: "call-1", Type: "function", Name: "echo", Args: []byte(`{"text":"hello"}`)}}},
 		{{Type: ai.TokenTypeText, Text: "primary"}},
 	}}
@@ -328,6 +328,7 @@ func TestTraceContextPropagatesAcrossRetriesToolsAndNestedMiddleware(t *testing.
 	if err != nil {
 		t.Fatalf("NewRun failed: %v", err)
 	}
+	workflow.Loop.RetryPolicy = &loop.RetryPolicy{MaxRetries: 1}
 	traceContext.UserID = "mutated-user"
 	traceContext.Tags[0] = "mutated-tag"
 	traceContext.Metadata["feature"] = "mutated-feature"

--- a/agent/summary/summary.go
+++ b/agent/summary/summary.go
@@ -29,6 +29,7 @@ type Config struct {
 	MaxLoopIterations int
 	MaxTokens         int
 	Tokenizer         ai.Tokenizer
+	RetryPolicy       *loop.RetryPolicy
 }
 
 type Option func(*Config)
@@ -54,6 +55,14 @@ func WithMaxLoopIterations(maxLoopIterations int) Option {
 func WithMaxTokens(maxTokens int) Option {
 	return func(config *Config) {
 		config.MaxTokens = maxTokens
+	}
+}
+
+// WithRetryPolicy configures opt-in classified retries for summary runs.
+func WithRetryPolicy(policy loop.RetryPolicy) Option {
+	return func(config *Config) {
+		copy := policy
+		config.RetryPolicy = &copy
 	}
 }
 
@@ -86,7 +95,8 @@ func Definition(model ai.Model, opts ...Option) agent.Definition {
 				Tokenizer:          config.Tokenizer,
 			}), nil
 		},
-		Tokenizer: config.Tokenizer,
+		Tokenizer:   config.Tokenizer,
+		RetryPolicy: config.RetryPolicy,
 		Limits: agent.Limits{
 			MaxLoopIterations: config.MaxLoopIterations,
 			MaxTokens:         config.MaxTokens,

--- a/agent/summary/summary.go
+++ b/agent/summary/summary.go
@@ -27,7 +27,6 @@ type Config struct {
 	SystemPrompt      string
 	Tools             []loop.Tool
 	MaxLoopIterations int
-	RetryCount        int
 	MaxTokens         int
 	Tokenizer         ai.Tokenizer
 }
@@ -49,12 +48,6 @@ func WithTools(tools ...loop.Tool) Option {
 func WithMaxLoopIterations(maxLoopIterations int) Option {
 	return func(config *Config) {
 		config.MaxLoopIterations = maxLoopIterations
-	}
-}
-
-func WithRetryCount(retryCount int) Option {
-	return func(config *Config) {
-		config.RetryCount = retryCount
 	}
 }
 
@@ -96,7 +89,6 @@ func Definition(model ai.Model, opts ...Option) agent.Definition {
 		Tokenizer: config.Tokenizer,
 		Limits: agent.Limits{
 			MaxLoopIterations: config.MaxLoopIterations,
-			RetryCount:        config.RetryCount,
 			MaxTokens:         config.MaxTokens,
 		},
 	}

--- a/agent/summary/summary_test.go
+++ b/agent/summary/summary_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lace-ai/gai/agent/summary"
 	"github.com/lace-ai/gai/ai"
+	"github.com/lace-ai/gai/loop"
 	"github.com/lace-ai/gai/testutil/mocks"
 )
 
@@ -52,6 +53,15 @@ func TestDefinitionAllowsSystemPromptOverride(t *testing.T) {
 	}
 	if !strings.Contains(model.request.Prompt, "custom summary system") {
 		t.Fatalf("expected custom system prompt: %q", model.request.Prompt)
+	}
+}
+
+func TestDefinitionConfiguresRetryPolicy(t *testing.T) {
+	t.Parallel()
+
+	def := summary.Definition(&recordingModel{}, summary.WithRetryPolicy(loop.RetryPolicy{MaxRetries: 2}))
+	if def.RetryPolicy == nil || def.RetryPolicy.MaxRetries != 2 {
+		t.Fatalf("retry policy = %#v, want MaxRetries 2", def.RetryPolicy)
 	}
 }
 

--- a/agent/workflow_test.go
+++ b/agent/workflow_test.go
@@ -325,7 +325,6 @@ func TestAgentMiddlewareErrorPolicy(t *testing.T) {
 			Prompt: func(_ context.Context, input agent.RunInput) (gaictx.PromptBuilder, error) {
 				return &testPromptBuilder{}, nil
 			},
-			Limits: agent.Limits{RetryCount: 1},
 		})
 	}
 
@@ -411,7 +410,6 @@ func TestAgentMiddlewareRunPolicy(t *testing.T) {
 			Prompt: func(_ context.Context, input agent.RunInput) (gaictx.PromptBuilder, error) {
 				return &testPromptBuilder{}, nil
 			},
-			Limits:     agent.Limits{RetryCount: 1},
 			Middleware: []agent.Middleware{middleware},
 		})
 	}

--- a/ai/anthropic/model.go
+++ b/ai/anthropic/model.go
@@ -549,9 +549,13 @@ func streamToolCall(block *streamBlock) (*ai.ToolCall, error) {
 }
 
 func anthropicHTTPStatus(err error) int {
-	var providerErr *Error
+	var providerErr *ai.ProviderError
 	if errors.As(err, &providerErr) {
 		return providerErr.StatusCode
+	}
+	var anthropicErr *Error
+	if errors.As(err, &anthropicErr) {
+		return anthropicErr.StatusCode
 	}
 	return 0
 }

--- a/ai/anthropic/model.go
+++ b/ai/anthropic/model.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	antropic "github.com/anthropics/anthropic-sdk-go"
@@ -384,6 +385,18 @@ func localError(err error) error {
 	return &Error{StatusCode: sdkErr.StatusCode, Type: string(sdkErr.Type()), Message: message}
 }
 
+func classifyProviderError(err error) error {
+	var sdkErr *antropic.Error
+	if !errors.As(err, &sdkErr) || sdkErr == nil {
+		return err
+	}
+	var header http.Header
+	if sdkErr.Response != nil {
+		header = sdkErr.Response.Header
+	}
+	return ai.ClassifyProviderError(err, sdkErr.StatusCode, string(sdkErr.Type()), sdkErr.RequestID, header)
+}
+
 func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.Token {
 	out := make(chan ai.Token, 1)
 	go func() {
@@ -499,7 +512,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			}
 		}
 		if streamErr == nil {
-			streamErr = localError(stream.Err())
+			streamErr = classifyProviderError(stream.Err())
 		}
 		if streamErr == nil && len(blocks) != 0 {
 			streamErr = fmt.Errorf("anthropic stream ended with %d open content block(s)", len(blocks))

--- a/ai/anthropic/model_test.go
+++ b/ai/anthropic/model_test.go
@@ -431,3 +431,24 @@ func TestCountTokens(t *testing.T) {
 		t.Fatalf("Tokenize error = %v", err)
 	}
 }
+
+func TestGenerateStreamClassifiesProviderRateLimit(t *testing.T) {
+	m := testModel(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("request-id", "req_anthropic")
+		w.Header().Set("Retry-After", "3")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`))
+	})
+	for token := range m.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+		if token.Type != ai.TokenTypeErr {
+			continue
+		}
+		var providerErr *ai.ProviderError
+		if !errors.As(token.Err, &providerErr) || providerErr.Kind != ai.ProviderErrorRateLimited || providerErr.StatusCode != http.StatusTooManyRequests || providerErr.Code != "rate_limit_error" || providerErr.RequestID != "req_anthropic" || providerErr.RetryAfter != 3*time.Second || errors.Unwrap(providerErr) == nil {
+			t.Fatalf("provider error = %#v", token.Err)
+		}
+		return
+	}
+	t.Fatal("expected stream error")
+}

--- a/ai/anthropic/model_test.go
+++ b/ai/anthropic/model_test.go
@@ -433,6 +433,7 @@ func TestCountTokens(t *testing.T) {
 }
 
 func TestGenerateStreamClassifiesProviderRateLimit(t *testing.T) {
+	recorder := obstest.Install(t)
 	m := testModel(t, func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("request-id", "req_anthropic")
@@ -440,6 +441,7 @@ func TestGenerateStreamClassifiesProviderRateLimit(t *testing.T) {
 		w.WriteHeader(http.StatusTooManyRequests)
 		_, _ = w.Write([]byte(`{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`))
 	})
+	sawError := false
 	for token := range m.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
 		if token.Type != ai.TokenTypeErr {
 			continue
@@ -448,7 +450,13 @@ func TestGenerateStreamClassifiesProviderRateLimit(t *testing.T) {
 		if !errors.As(token.Err, &providerErr) || providerErr.Kind != ai.ProviderErrorRateLimited || providerErr.StatusCode != http.StatusTooManyRequests || providerErr.Code != "rate_limit_error" || providerErr.RequestID != "req_anthropic" || providerErr.RetryAfter != 3*time.Second || errors.Unwrap(providerErr) == nil {
 			t.Fatalf("provider error = %#v", token.Err)
 		}
-		return
+		sawError = true
 	}
-	t.Fatal("expected stream error")
+	if !sawError {
+		t.Fatal("expected stream error")
+	}
+	attrs := obstest.Attributes(obstest.RequireGenerationSpans(t, recorder, 1)[0])
+	if got := attrs["http.response.status_code"].AsInt64(); got != http.StatusTooManyRequests {
+		t.Fatalf("HTTP status attribute = %d, want %d", got, http.StatusTooManyRequests)
+	}
 }

--- a/ai/errors.go
+++ b/ai/errors.go
@@ -1,6 +1,50 @@
 package ai
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ProviderErrorKind is a provider-neutral classification used by retry policy.
+type ProviderErrorKind string
+
+const (
+	ProviderErrorUnknown        ProviderErrorKind = "unknown"
+	ProviderErrorRateLimited    ProviderErrorKind = "rate_limited"
+	ProviderErrorTransient      ProviderErrorKind = "transient"
+	ProviderErrorAuthentication ProviderErrorKind = "authentication"
+	ProviderErrorInvalidRequest ProviderErrorKind = "invalid_request"
+	ProviderErrorUnsupported    ProviderErrorKind = "unsupported"
+)
+
+// ProviderError carries safe, provider-neutral failure metadata. Provider
+// adapters should wrap vendor errors in this type before returning them.
+type ProviderError struct {
+	Kind       ProviderErrorKind
+	StatusCode int
+	Code       string
+	RequestID  string
+	RetryAfter time.Duration
+	Err        error
+}
+
+func (e *ProviderError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+	if e.Err != nil {
+		return fmt.Sprintf("provider %s error: %v", e.Kind, e.Err)
+	}
+	return fmt.Sprintf("provider %s error", e.Kind)
+}
+
+func (e *ProviderError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
 
 var (
 	// ErrModelNotFound indicates that a requested model is unavailable.

--- a/ai/errors.go
+++ b/ai/errors.go
@@ -3,6 +3,9 @@ package ai
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -44,6 +47,60 @@ func (e *ProviderError) Unwrap() error {
 		return nil
 	}
 	return e.Err
+}
+
+// ClassifyProviderError adds provider-neutral retry metadata to an HTTP API
+// error. It preserves err in the returned error chain.
+func ClassifyProviderError(err error, statusCode int, code, requestID string, header http.Header) error {
+	if err == nil {
+		return nil
+	}
+	var provider *ProviderError
+	if errors.As(err, &provider) {
+		return err
+	}
+	return &ProviderError{
+		Kind:       providerErrorKind(statusCode, code),
+		StatusCode: statusCode,
+		Code:       code,
+		RequestID:  requestID,
+		RetryAfter: retryAfter(header.Get("Retry-After")),
+		Err:        err,
+	}
+}
+
+func providerErrorKind(statusCode int, code string) ProviderErrorKind {
+	code = strings.ToLower(code)
+	switch {
+	case statusCode == http.StatusTooManyRequests || strings.Contains(code, "rate_limit") || strings.Contains(code, "rate-limit"):
+		return ProviderErrorRateLimited
+	case statusCode == http.StatusRequestTimeout || statusCode == http.StatusConflict || statusCode == http.StatusTooEarly || statusCode >= http.StatusInternalServerError || strings.Contains(code, "overload") || strings.Contains(code, "temporar"):
+		return ProviderErrorTransient
+	case statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden || strings.Contains(code, "auth") || strings.Contains(code, "api_key"):
+		return ProviderErrorAuthentication
+	case statusCode == http.StatusNotImplemented || strings.Contains(code, "unsupported"):
+		return ProviderErrorUnsupported
+	case statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError:
+		return ProviderErrorInvalidRequest
+	default:
+		return ProviderErrorUnknown
+	}
+}
+
+func retryAfter(value string) time.Duration {
+	value = strings.TrimSpace(value)
+	if seconds, err := strconv.ParseInt(value, 10, 64); err == nil {
+		if seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+		return 0
+	}
+	if retryAt, err := http.ParseTime(value); err == nil {
+		if delay := time.Until(retryAt); delay > 0 {
+			return delay
+		}
+	}
+	return 0
 }
 
 var (

--- a/ai/errors.go
+++ b/ai/errors.go
@@ -74,12 +74,12 @@ func providerErrorKind(statusCode int, code string) ProviderErrorKind {
 	switch {
 	case statusCode == http.StatusTooManyRequests || strings.Contains(code, "rate_limit") || strings.Contains(code, "rate-limit"):
 		return ProviderErrorRateLimited
+	case statusCode == http.StatusNotImplemented || strings.Contains(code, "unsupported"):
+		return ProviderErrorUnsupported
 	case statusCode == http.StatusRequestTimeout || statusCode == http.StatusConflict || statusCode == http.StatusTooEarly || statusCode >= http.StatusInternalServerError || strings.Contains(code, "server_error") || strings.Contains(code, "overload") || strings.Contains(code, "temporar"):
 		return ProviderErrorTransient
 	case statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden || strings.Contains(code, "auth") || strings.Contains(code, "api_key"):
 		return ProviderErrorAuthentication
-	case statusCode == http.StatusNotImplemented || strings.Contains(code, "unsupported"):
-		return ProviderErrorUnsupported
 	case statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError:
 		return ProviderErrorInvalidRequest
 	default:

--- a/ai/errors.go
+++ b/ai/errors.go
@@ -74,7 +74,7 @@ func providerErrorKind(statusCode int, code string) ProviderErrorKind {
 	switch {
 	case statusCode == http.StatusTooManyRequests || strings.Contains(code, "rate_limit") || strings.Contains(code, "rate-limit"):
 		return ProviderErrorRateLimited
-	case statusCode == http.StatusRequestTimeout || statusCode == http.StatusConflict || statusCode == http.StatusTooEarly || statusCode >= http.StatusInternalServerError || strings.Contains(code, "overload") || strings.Contains(code, "temporar"):
+	case statusCode == http.StatusRequestTimeout || statusCode == http.StatusConflict || statusCode == http.StatusTooEarly || statusCode >= http.StatusInternalServerError || strings.Contains(code, "server_error") || strings.Contains(code, "overload") || strings.Contains(code, "temporar"):
 		return ProviderErrorTransient
 	case statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden || strings.Contains(code, "auth") || strings.Contains(code, "api_key"):
 		return ProviderErrorAuthentication

--- a/ai/gemini/model.go
+++ b/ai/gemini/model.go
@@ -70,6 +70,18 @@ func geminiHTTPStatus(err error) int {
 	return 0
 }
 
+func classifyProviderError(err error) error {
+	var apiErr *genai.APIError
+	if errors.As(err, &apiErr) && apiErr != nil {
+		return ai.ClassifyProviderError(err, apiErr.Code, "", "", nil)
+	}
+	var apiErrValue genai.APIError
+	if errors.As(err, &apiErrValue) {
+		return ai.ClassifyProviderError(err, apiErrValue.Code, "", "", nil)
+	}
+	return err
+}
+
 func (m *Model) Close() error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -164,7 +176,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 		ctx = generationCtx
 		for resp, err := range client.Models.GenerateContentStream(generationCtx, m.name, contents, config) {
 			if err != nil {
-				streamErr = fmt.Errorf("error generating content stream: %w", err)
+				streamErr = classifyProviderError(fmt.Errorf("error generating content stream: %w", err))
 				if m.debug != nil {
 					m.debug.Emit(ctx, gai.DebugEvent{
 						Name:   "gemini_stream_generation_failed",

--- a/ai/gemini/model_test.go
+++ b/ai/gemini/model_test.go
@@ -254,6 +254,10 @@ func TestModelGenerateStreamRecordsAPIErrorStatus(t *testing.T) {
 	if streamErr == nil {
 		t.Fatal("stream error = nil, want API error")
 	}
+	var providerErr *ai.ProviderError
+	if !errors.As(streamErr, &providerErr) || providerErr.Kind != ai.ProviderErrorRateLimited || providerErr.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("stream error = %#v, want classified rate-limit error", streamErr)
+	}
 	span := obstest.RequireGenerationSpans(t, recorder, 1)[0]
 	attrs := obstest.Attributes(span)
 	if attrs["http.response.status_code"].AsInt64() != http.StatusTooManyRequests {

--- a/ai/mistral/errors.go
+++ b/ai/mistral/errors.go
@@ -1,6 +1,7 @@
 package mistral
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 )
@@ -36,4 +37,20 @@ func (e *HTTPError) ResponseBody() []byte {
 		return nil
 	}
 	return append([]byte(nil), e.body...)
+}
+
+func mistralErrorCode(body []byte) string {
+	var payload struct {
+		Code  string `json:"code"`
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if json.Unmarshal(body, &payload) != nil {
+		return ""
+	}
+	if payload.Error.Code != "" {
+		return payload.Error.Code
+	}
+	return payload.Code
 }

--- a/ai/mistral/model.go
+++ b/ai/mistral/model.go
@@ -660,7 +660,7 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 					Fields: fields,
 				})
 			}
-			streamErr = newHTTPError("chat stream", res.StatusCode, resBody)
+			streamErr = ai.ClassifyProviderError(newHTTPError("chat stream", res.StatusCode, resBody), res.StatusCode, mistralErrorCode(resBody), res.Header.Get("x-request-id"), res.Header)
 			if !emit(ai.Token{
 				Err:  streamErr,
 				Type: ai.TokenTypeErr,

--- a/ai/mistral/model_test.go
+++ b/ai/mistral/model_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/lace-ai/gai"
 	"github.com/lace-ai/gai/ai"
@@ -853,4 +854,31 @@ func TestModelGenerateStreamDetectsTextEncodedToolCall(t *testing.T) {
 	if gotText != "" {
 		t.Fatalf("expected no text tokens after tool-call detection, got %q", gotText)
 	}
+}
+
+func TestModelGenerateStreamClassifiesProviderRateLimit(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("x-request-id", "req_mistral")
+		w.Header().Set("Retry-After", "2")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":"rate_limit_exceeded"}}`))
+	}))
+	defer ts.Close()
+	p := New("test-key", nil)
+	p.baseURL = ts.URL
+	m, err := p.Model(MistralSmallLatest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for token := range m.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+		if token.Type != ai.TokenTypeErr {
+			continue
+		}
+		var providerErr *ai.ProviderError
+		if !errors.As(token.Err, &providerErr) || providerErr.Kind != ai.ProviderErrorRateLimited || providerErr.StatusCode != http.StatusTooManyRequests || providerErr.Code != "rate_limit_exceeded" || providerErr.RequestID != "req_mistral" || providerErr.RetryAfter != 2*time.Second || errors.Unwrap(providerErr) == nil {
+			t.Fatalf("provider error = %#v", token.Err)
+		}
+		return
+	}
+	t.Fatal("expected stream error")
 }

--- a/ai/openai/model.go
+++ b/ai/openai/model.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"sort"
 	"strings"
 
@@ -15,6 +16,18 @@ import (
 	"github.com/openai/openai-go/packages/param"
 	"github.com/openai/openai-go/shared"
 )
+
+func classifyProviderError(err error) error {
+	var apiErr *sdk.Error
+	if !errors.As(err, &apiErr) || apiErr == nil {
+		return err
+	}
+	var header http.Header
+	if apiErr.Response != nil {
+		header = apiErr.Response.Header
+	}
+	return ai.ClassifyProviderError(err, apiErr.StatusCode, apiErr.Code, header.Get("x-request-id"), header)
+}
 
 // Model is an OpenAI chat-completions model.
 type Model struct {
@@ -210,8 +223,8 @@ func (m *Model) GenerateStream(ctx context.Context, req ai.AIRequest) <-chan ai.
 			}
 		}
 		if err := stream.Err(); err != nil {
-			streamErr = err
-			emit(ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
+			streamErr = classifyProviderError(err)
+			emit(ai.Token{Type: ai.TokenTypeErr, Err: streamErr, Text: streamErr.Error()})
 			return
 		}
 		sendStreamToolCalls(emit, calls)

--- a/ai/openai/model_test.go
+++ b/ai/openai/model_test.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/lace-ai/gai/ai"
 	"github.com/lace-ai/gai/internal/obstest"
@@ -973,4 +974,32 @@ func mustMarshalJSON(t *testing.T, value string) string {
 		t.Fatalf("marshal JSON: %v", err)
 	}
 	return string(raw)
+}
+
+func TestModelGenerateStreamClassifiesProviderRateLimit(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("x-request-id", "req_openai")
+		w.Header().Set("Retry-After", "4")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"code":"rate_limit_exceeded","message":"slow down","type":"rate_limit_error"}}`))
+	}))
+	defer ts.Close()
+	p := New("test-key", nil)
+	p.baseURL = ts.URL
+	m, err := p.Model(GPT41Mini)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for token := range m.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+		if token.Type != ai.TokenTypeErr {
+			continue
+		}
+		var providerErr *ai.ProviderError
+		if !errors.As(token.Err, &providerErr) || providerErr.Kind != ai.ProviderErrorRateLimited || providerErr.StatusCode != http.StatusTooManyRequests || providerErr.Code != "rate_limit_exceeded" || providerErr.RequestID != "req_openai" || providerErr.RetryAfter != 4*time.Second || errors.Unwrap(providerErr) == nil {
+			t.Fatalf("provider error = %#v", token.Err)
+		}
+		return
+	}
+	t.Fatal("expected stream error")
 }

--- a/ai/openai/model_test.go
+++ b/ai/openai/model_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"slices"
@@ -423,6 +424,47 @@ func TestModelGenerateStreamWithResponsesTransportFallsBackForEmptyFailedRespons
 	}
 	if len(tokens) != 1 || tokens[0].Type != ai.TokenTypeErr || tokens[0].Err == nil || tokens[0].Err.Error() != "OpenAI Responses API: response failed" {
 		t.Fatalf("tokens = %#v", tokens)
+	}
+}
+
+func TestModelGenerateStreamWithResponsesTransportClassifiesFailedResponse(t *testing.T) {
+	tests := []struct {
+		name string
+		code string
+		want ai.ProviderErrorKind
+	}{
+		{name: "rate limit", code: "rate_limit_exceeded", want: ai.ProviderErrorRateLimited},
+		{name: "server error", code: "server_error", want: ai.ProviderErrorTransient},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/responses" {
+					t.Fatalf("unexpected path %q", r.URL.Path)
+				}
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = fmt.Fprintf(w, "data: {\"type\":\"response.failed\",\"response\":{\"id\":\"resp_1\",\"error\":{\"code\":%q,\"message\":\"provider failed\"}}}\n\n", tt.code)
+			}))
+			defer ts.Close()
+
+			p := New("test-key", nil, WithResponsesTransport())
+			p.baseURL = ts.URL
+			m, err := p.Model("gpt-5.6-terra")
+			if err != nil {
+				t.Fatal(err)
+			}
+			for token := range m.GenerateStream(t.Context(), ai.AIRequest{Prompt: "hello"}) {
+				if token.Type != ai.TokenTypeErr {
+					continue
+				}
+				var providerErr *ai.ProviderError
+				if !errors.As(token.Err, &providerErr) || providerErr.Kind != tt.want || providerErr.Code != tt.code || providerErr.RequestID != "resp_1" || errors.Unwrap(providerErr) == nil {
+					t.Fatalf("provider error = %#v", token.Err)
+				}
+				return
+			}
+			t.Fatal("expected stream error")
+		})
 	}
 }
 

--- a/ai/openai/responses.go
+++ b/ai/openai/responses.go
@@ -164,8 +164,8 @@ func (m *Model) generateResponsesStream(ctx context.Context, out chan<- ai.Token
 		}
 	}
 	if err := stream.Err(); err != nil {
-		streamErr = err
-		emit(ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
+		streamErr = classifyProviderError(err)
+		emit(ai.Token{Type: ai.TokenTypeErr, Err: streamErr, Text: streamErr.Error()})
 	}
 }
 

--- a/ai/openai/responses.go
+++ b/ai/openai/responses.go
@@ -150,14 +150,18 @@ func (m *Model) generateResponsesStream(ctx context.Context, out chan<- ai.Token
 			emit(ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
 			return
 		case "response.failed":
-			message := event.Response.Error.Message
+			response := event.Response
+			message := response.Error.Message
 			if message == "" {
-				message = string(event.Response.Error.Code)
+				message = string(response.Error.Code)
 			}
 			if message == "" {
 				message = "response failed"
 			}
 			err := fmt.Errorf("OpenAI Responses API: %s", message)
+			if response.Error.Code != "" {
+				err = ai.ClassifyProviderError(err, 0, string(response.Error.Code), response.ID, nil)
+			}
 			streamErr = err
 			emit(ai.Token{Type: ai.TokenTypeErr, Err: err, Text: err.Error()})
 			return

--- a/ai/response_test.go
+++ b/ai/response_test.go
@@ -3,10 +3,36 @@ package ai_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/lace-ai/gai/ai"
 )
+
+func TestClassifyProviderErrorPrioritizesUnsupported(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		code       string
+	}{
+		{name: "not implemented", statusCode: http.StatusNotImplemented},
+		{name: "unsupported server error", statusCode: http.StatusInternalServerError, code: "unsupported_feature"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ai.ClassifyProviderError(errors.New("provider error"), tt.statusCode, tt.code, "", nil)
+			var providerErr *ai.ProviderError
+			if !errors.As(err, &providerErr) {
+				t.Fatalf("error = %T, want *ai.ProviderError", err)
+			}
+			if providerErr.Kind != ai.ProviderErrorUnsupported {
+				t.Fatalf("kind = %q, want %q", providerErr.Kind, ai.ProviderErrorUnsupported)
+			}
+		})
+	}
+}
 
 func TestSendTokenStopsWhenContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/loop/event.go
+++ b/loop/event.go
@@ -41,6 +41,10 @@ type Event struct {
 	AttemptID      int
 	RetryCount     int
 	PartCount      int
+	// RetryReason classifies the error that triggered a retry.
+	RetryReason string
+	// RetryDelay is the backoff selected before the next attempt.
+	RetryDelay time.Duration
 
 	Token        *ai.Token
 	Iteration    *Iteration
@@ -69,12 +73,14 @@ func TokenEvent(iteration, attempt, retry int, token ai.Token) Event {
 	}
 }
 
-func RetryEvent(iteration, attempt, retry int, attemptIteration Iteration) Event {
+func RetryEvent(iteration, attempt, retry int, reason string, delay time.Duration, attemptIteration Iteration) Event {
 	return Event{
 		Type:           EventRetry,
 		IterationCount: iteration,
 		AttemptID:      attempt,
 		RetryCount:     retry,
+		RetryReason:    reason,
+		RetryDelay:     delay,
 		PartCount:      len(attemptIteration.Parts),
 		Iteration:      &attemptIteration,
 	}

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -244,14 +244,6 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 
 				iterCtx, iterState = runState.startIteration(ctx, iteration.Count, attempt)
 				iterCtx, cancel = context.WithCancel(iterCtx)
-				var attemptDeadline context.Context
-				if l.RetryPolicy != nil && l.RetryPolicy.AttemptTimeout > 0 {
-					var attemptCancel context.CancelFunc
-					attemptDeadline, attemptCancel = context.WithTimeout(iterCtx, l.RetryPolicy.AttemptTimeout)
-					previousCancel := cancel
-					cancel = func() { attemptCancel(); previousCancel() }
-					iterCtx = attemptDeadline
-				}
 				attemptID := iterState.attemptID()
 				if err := iterCtx.Err(); err != nil {
 					sendAttemptCanceled(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, err)
@@ -297,6 +289,14 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 				request := renderedPromptRequest(prompt, l.MaxTokens, toolDefinitions, l.ResponseFormat, l.Reasoning)
 				request.Messages = nativeMessages
 
+				var attemptDeadline context.Context
+				if l.RetryPolicy != nil && l.RetryPolicy.AttemptTimeout > 0 {
+					var attemptCancel context.CancelFunc
+					attemptDeadline, attemptCancel = context.WithTimeout(iterCtx, l.RetryPolicy.AttemptTimeout)
+					previousCancel := cancel
+					cancel = func() { attemptCancel(); previousCancel() }
+					iterCtx = attemptDeadline
+				}
 				tokens := l.Model.GenerateStream(iterCtx, request)
 
 				retrying := false

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -13,7 +13,6 @@ import (
 
 const (
 	defaultMaxLoopIterations = 8
-	defaultRetryCount        = 3
 )
 
 // ToolTransportMode controls whether a loop sends tool definitions through the
@@ -60,9 +59,7 @@ type Loop struct {
 	ResponseFormat ai.ResponseFormat
 	// Reasoning configures model reasoning/thinking behavior for each model generation.
 	Reasoning ai.ReasoningConfig
-	// RetryCount is the number of model stream failures retried before stopping.
-	RetryCount int
-	// RetryPolicy enables classified retries. Nil preserves RetryCount behavior.
+	// RetryPolicy enables classified retries. Nil disables retries.
 	RetryPolicy *RetryPolicy
 	// PromptBuilder constructs the prompt for each iteration.
 	PromptBuilder gaictx.PromptBuilder
@@ -95,13 +92,12 @@ func (l *Loop) Validate() error {
 	return nil
 }
 
-// New constructs a Loop with default iteration and retry limits.
+// New constructs a Loop with the default iteration limit.
 func New(model ai.Model, tools []Tool, promptBuilder gaictx.PromptBuilder, toolResponseProcessor ToolResponseProcessor) *Loop {
 	l := &Loop{
 		Model:                 model,
 		Tools:                 tools,
 		MaxLoopIterations:     defaultMaxLoopIterations,
-		RetryCount:            defaultRetryCount,
 		PromptBuilder:         promptBuilder,
 		ToolResponseProcessor: toolResponseProcessor,
 	}
@@ -325,9 +321,9 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 							}
 						}
 
-						retryLimit := l.RetryCount
-						canRetry := runState.canRetry(retryLimit)
-						retryable := canRetry
+						retryLimit := 0
+						canRetry := false
+						retryable := false
 						if l.RetryPolicy != nil {
 							retryLimit = l.RetryPolicy.MaxRetries
 							retryable = l.RetryPolicy.isRetryable(t.Err)

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -319,8 +319,10 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 							}
 						}
 
-						canRetry := runState.canRetry(l.RetryCount)
+						retryLimit := l.RetryCount
+						canRetry := runState.canRetry(retryLimit)
 						if l.RetryPolicy != nil {
+							retryLimit = l.RetryPolicy.MaxRetries
 							canRetry = l.RetryPolicy.ShouldRetry(runState.retryCount, t.Err)
 						}
 						if canRetry {
@@ -328,7 +330,7 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 							break
 						}
 
-						iterationErr = fmt.Errorf("%w: limit=%d: %w", ErrMaxRetries, l.RetryCount, t.Err)
+						iterationErr = fmt.Errorf("%w: limit=%d: %w", ErrMaxRetries, retryLimit, t.Err)
 						sendAttemptError(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, iterationErr)
 						cancel()
 						iterState.finish(iterationErr)

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -84,6 +84,11 @@ func (l *Loop) Validate() error {
 	if l.PromptBuilder == nil {
 		return ErrPromptNotConfigured
 	}
+	if l.RetryPolicy != nil {
+		if err := l.RetryPolicy.Validate(); err != nil {
+			return err
+		}
+	}
 	if err := l.ResponseFormat.Validate(); err != nil {
 		return err
 	}

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -334,7 +334,7 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 							break
 						}
 
-						if l.RetryPolicy != nil && !retryable {
+						if l.RetryPolicy == nil || !retryable {
 							iterationErr = t.Err
 						} else {
 							iterationErr = fmt.Errorf("%w: limit=%d: %w", ErrMaxRetries, retryLimit, t.Err)

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -289,15 +289,16 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 				request := renderedPromptRequest(prompt, l.MaxTokens, toolDefinitions, l.ResponseFormat, l.Reasoning)
 				request.Messages = nativeMessages
 
+				modelCtx := iterCtx
 				var attemptDeadline context.Context
 				if l.RetryPolicy != nil && l.RetryPolicy.AttemptTimeout > 0 {
 					var attemptCancel context.CancelFunc
 					attemptDeadline, attemptCancel = context.WithTimeout(iterCtx, l.RetryPolicy.AttemptTimeout)
 					previousCancel := cancel
 					cancel = func() { attemptCancel(); previousCancel() }
-					iterCtx = attemptDeadline
+					modelCtx = attemptDeadline
 				}
-				tokens := l.Model.GenerateStream(iterCtx, request)
+				tokens := l.Model.GenerateStream(modelCtx, request)
 
 				retrying := false
 				var retryErr error

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -305,15 +305,18 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 					if t.Err != nil {
 						retryErr = t.Err
 						attemptTimeout := attemptDeadline != nil && errors.Is(attemptDeadline.Err(), context.DeadlineExceeded) && callerCtx.Err() == nil && ctx.Err() == nil
-						if attemptTimeout {
+						var providerErr *ai.ProviderError
+						if attemptTimeout && errors.Is(t.Err, context.DeadlineExceeded) && !errors.As(t.Err, &providerErr) {
 							t.Err = ErrAttemptTimeout
 							retryErr = t.Err
-						} else if cancelErr := cancellationError(iterCtx, t.Err); cancelErr != nil {
-							sendAttemptCanceled(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, cancelErr)
-							cancel()
-							iterState.markCanceled(cancelErr)
-							iterState.finish(nil)
-							return
+						} else if !attemptTimeout {
+							if cancelErr := cancellationError(iterCtx, t.Err); cancelErr != nil {
+								sendAttemptCanceled(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, cancelErr)
+								cancel()
+								iterState.markCanceled(cancelErr)
+								iterState.finish(nil)
+								return
+							}
 						}
 
 						canRetry := runState.canRetry(l.RetryCount)

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -327,16 +327,18 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 
 						retryLimit := l.RetryCount
 						canRetry := runState.canRetry(retryLimit)
+						retryable := canRetry
 						if l.RetryPolicy != nil {
 							retryLimit = l.RetryPolicy.MaxRetries
-							canRetry = l.RetryPolicy.ShouldRetry(runState.retryCount, t.Err)
+							retryable = l.RetryPolicy.isRetryable(t.Err)
+							canRetry = l.RetryPolicy.hasRetryBudget(runState.retryCount) && retryable
 						}
 						if canRetry {
 							retrying = true
 							break
 						}
 
-						if l.RetryPolicy != nil && runState.retryCount < retryLimit {
+						if l.RetryPolicy != nil && !retryable {
 							iterationErr = t.Err
 						} else {
 							iterationErr = fmt.Errorf("%w: limit=%d: %w", ErrMaxRetries, retryLimit, t.Err)

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -412,6 +412,10 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 				if l.RetryPolicy != nil {
 					delay := l.RetryPolicy.Backoff(runState.retryCount-1, retryErr)
 					if delay > 0 {
+						// The backoff is scoped to the run context, not the failed
+						// attempt context. Cancel the attempt before waiting so a model
+						// producer cannot remain blocked while the retry is delayed.
+						cancel()
 						if err := l.RetryPolicy.wait(ctx, delay); err != nil {
 							if cancelErr := cancellationError(ctx, err); cancelErr != nil {
 								sendAttemptCanceled(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, cancelErr)

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -62,6 +62,8 @@ type Loop struct {
 	Reasoning ai.ReasoningConfig
 	// RetryCount is the number of model stream failures retried before stopping.
 	RetryCount int
+	// RetryPolicy enables classified retries. Nil preserves RetryCount behavior.
+	RetryPolicy *RetryPolicy
 	// PromptBuilder constructs the prompt for each iteration.
 	PromptBuilder gaictx.PromptBuilder
 	// ToolResponseProcessor optionally processes tool responses after they are recorded on the iteration and before it is persisted.
@@ -183,6 +185,12 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 	}
 
 	go func() {
+		callerCtx := ctx
+		if l.RetryPolicy != nil && l.RetryPolicy.TotalTimeout > 0 {
+			var totalCancel context.CancelFunc
+			ctx, totalCancel = context.WithTimeout(ctx, l.RetryPolicy.TotalTimeout)
+			defer totalCancel()
+		}
 		ctx, runState := newLoopRunState(ctx, l)
 		defer runState.finish()
 		defer close(events)
@@ -236,6 +244,14 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 
 				iterCtx, iterState = runState.startIteration(ctx, iteration.Count, attempt)
 				iterCtx, cancel = context.WithCancel(iterCtx)
+				var attemptDeadline context.Context
+				if l.RetryPolicy != nil && l.RetryPolicy.AttemptTimeout > 0 {
+					var attemptCancel context.CancelFunc
+					attemptDeadline, attemptCancel = context.WithTimeout(iterCtx, l.RetryPolicy.AttemptTimeout)
+					previousCancel := cancel
+					cancel = func() { attemptCancel(); previousCancel() }
+					iterCtx = attemptDeadline
+				}
 				attemptID := iterState.attemptID()
 				if err := iterCtx.Err(); err != nil {
 					sendAttemptCanceled(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, err)
@@ -284,9 +300,15 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 				tokens := l.Model.GenerateStream(iterCtx, request)
 
 				retrying := false
+				var retryErr error
 				for t := range tokens {
 					if t.Err != nil {
-						if cancelErr := cancellationError(iterCtx, t.Err); cancelErr != nil {
+						retryErr = t.Err
+						attemptTimeout := attemptDeadline != nil && errors.Is(attemptDeadline.Err(), context.DeadlineExceeded) && callerCtx.Err() == nil && ctx.Err() == nil
+						if attemptTimeout {
+							t.Err = ErrAttemptTimeout
+							retryErr = t.Err
+						} else if cancelErr := cancellationError(iterCtx, t.Err); cancelErr != nil {
 							sendAttemptCanceled(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, cancelErr)
 							cancel()
 							iterState.markCanceled(cancelErr)
@@ -294,7 +316,11 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 							return
 						}
 
-						if runState.canRetry(l.RetryCount) {
+						canRetry := runState.canRetry(l.RetryCount)
+						if l.RetryPolicy != nil {
+							canRetry = l.RetryPolicy.ShouldRetry(runState.retryCount, t.Err)
+						}
+						if canRetry {
 							retrying = true
 							break
 						}
@@ -334,7 +360,20 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 					}
 				}
 
-				if err := iterCtx.Err(); err != nil {
+				attemptTimeout := attemptDeadline != nil && errors.Is(attemptDeadline.Err(), context.DeadlineExceeded) && callerCtx.Err() == nil && ctx.Err() == nil
+				if attemptTimeout && !retrying {
+					retryErr = ErrAttemptTimeout
+					if l.RetryPolicy.ShouldRetry(runState.retryCount, ErrAttemptTimeout) {
+						retrying = true
+					} else {
+						iterationErr = fmt.Errorf("%w: limit=%d: %w", ErrMaxRetries, l.RetryPolicy.MaxRetries, ErrAttemptTimeout)
+						sendAttemptError(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, iterationErr)
+						cancel()
+						iterState.finish(iterationErr)
+						return
+					}
+				}
+				if err := iterCtx.Err(); err != nil && !(retrying && attemptTimeout) {
 					sendAttemptCanceled(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, err)
 					cancel()
 					iterState.markCanceled(err)
@@ -359,6 +398,22 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 					cancel()
 					iterState.finish(nil)
 					return
+				}
+				if l.RetryPolicy != nil {
+					delay := l.RetryPolicy.Backoff(runState.retryCount-1, retryErr)
+					if delay > 0 {
+						timer := time.NewTimer(delay)
+						select {
+						case <-ctx.Done():
+							timer.Stop()
+							sendAttemptCanceled(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, ctx.Err())
+							cancel()
+							iterState.markCanceled(ctx.Err())
+							iterState.finish(nil)
+							return
+						case <-timer.C:
+						}
+					}
 				}
 				cancel()
 				iterState.finish(nil)

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -401,9 +401,13 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 				}
 
 				runState.retry()
+				delay := time.Duration(0)
+				if l.RetryPolicy != nil {
+					delay = l.RetryPolicy.Backoff(runState.retryCount-1, retryErr)
+				}
 				iterState.recordIteration(attemptIteration)
-				iterState.markRetrying(runState.retryCount)
-				if err := sendEvent(ctx, events, RetryEvent(iteration.Count, attemptID, runState.retryCount, attemptIteration)); err != nil {
+				iterState.markRetrying(runState.retryCount, retryReason(retryErr), delay)
+				if err := sendEvent(ctx, events, RetryEvent(iteration.Count, attemptID, runState.retryCount, retryReason(retryErr), delay, attemptIteration)); err != nil {
 					if cancelErr := cancellationError(iterCtx, err); cancelErr != nil {
 						sendAttemptCanceled(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, cancelErr)
 						iterState.markCanceled(cancelErr)
@@ -415,7 +419,6 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 					return
 				}
 				if l.RetryPolicy != nil {
-					delay := l.RetryPolicy.Backoff(runState.retryCount-1, retryErr)
 					if delay > 0 {
 						// The backoff is scoped to the run context, not the failed
 						// attempt context. Cancel the attempt before waiting so a model

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -407,16 +407,19 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 				if l.RetryPolicy != nil {
 					delay := l.RetryPolicy.Backoff(runState.retryCount-1, retryErr)
 					if delay > 0 {
-						timer := time.NewTimer(delay)
-						select {
-						case <-ctx.Done():
-							timer.Stop()
-							sendAttemptCanceled(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, ctx.Err())
+						if err := l.RetryPolicy.wait(ctx, delay); err != nil {
+							if cancelErr := cancellationError(ctx, err); cancelErr != nil {
+								sendAttemptCanceled(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, cancelErr)
+								cancel()
+								iterState.markCanceled(cancelErr)
+								iterState.finish(nil)
+								return
+							}
+							iterationErr = fmt.Errorf("wait for retry: %w", err)
+							sendAttemptError(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, iterationErr)
 							cancel()
-							iterState.markCanceled(ctx.Err())
-							iterState.finish(nil)
+							iterState.finish(iterationErr)
 							return
-						case <-timer.C:
 						}
 					}
 				}

--- a/loop/loop.go
+++ b/loop/loop.go
@@ -330,7 +330,11 @@ func (l *Loop) Run(ctx context.Context) <-chan Event {
 							break
 						}
 
-						iterationErr = fmt.Errorf("%w: limit=%d: %w", ErrMaxRetries, retryLimit, t.Err)
+						if l.RetryPolicy != nil && runState.retryCount < retryLimit {
+							iterationErr = t.Err
+						} else {
+							iterationErr = fmt.Errorf("%w: limit=%d: %w", ErrMaxRetries, retryLimit, t.Err)
+						}
 						sendAttemptError(ctx, events, runState, iteration.Count, attemptID, runState.retryCount, &attemptIteration, iterationErr)
 						cancel()
 						iterState.finish(iterationErr)

--- a/loop/loop_obs.go
+++ b/loop/loop_obs.go
@@ -87,7 +87,6 @@ func newLoopRunState(ctx context.Context, l *Loop) (context.Context, *loopRunSta
 	modelName := ""
 	if l != nil {
 		maxIterations = l.MaxLoopIterations
-		retryLimit = l.RetryCount
 		if l.RetryPolicy != nil {
 			retryLimit = l.RetryPolicy.MaxRetries
 		}
@@ -133,13 +132,6 @@ func (s *loopRunState) recordToken(token ai.Token) {
 	if token.Type == ai.TokenTypeToolCall && token.ToolCall != nil {
 		s.stats.ToolCallCount++
 	}
-}
-
-func (s *loopRunState) canRetry(limit int) bool {
-	if s == nil {
-		return false
-	}
-	return s.retryCount < limit
 }
 
 func (s *loopRunState) retry() {

--- a/loop/loop_obs.go
+++ b/loop/loop_obs.go
@@ -88,6 +88,9 @@ func newLoopRunState(ctx context.Context, l *Loop) (context.Context, *loopRunSta
 	if l != nil {
 		maxIterations = l.MaxLoopIterations
 		retryLimit = l.RetryCount
+		if l.RetryPolicy != nil {
+			retryLimit = l.RetryPolicy.MaxRetries
+		}
 		maxTokens = l.MaxTokens
 		toolCount = len(l.Tools)
 		if l.Model != nil {

--- a/loop/loop_obs.go
+++ b/loop/loop_obs.go
@@ -4,12 +4,24 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"time"
 
 	"github.com/lace-ai/gai"
 	"github.com/lace-ai/gai/ai"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 )
+
+func retryReason(err error) string {
+	if errors.Is(err, ErrAttemptTimeout) {
+		return "attempt_timeout"
+	}
+	var providerErr *ai.ProviderError
+	if errors.As(err, &providerErr) && providerErr.Kind != "" {
+		return string(providerErr.Kind)
+	}
+	return string(ai.ProviderErrorUnknown)
+}
 
 const loopTracerName = "github.com/lace-ai/gai/loop"
 
@@ -57,6 +69,8 @@ type loopIterationStats struct {
 	AttemptID      int
 	PartCount      int
 	RetryCount     int
+	RetryReason    string
+	RetryDelay     time.Duration
 	ToolCallCount  int
 	ToolErrorCount int
 }
@@ -210,12 +224,14 @@ func (s *loopIterationState) recordIteration(iteration Iteration) {
 	}
 }
 
-func (s *loopIterationState) markRetrying(retryCount int) {
+func (s *loopIterationState) markRetrying(retryCount int, reason string, delay time.Duration) {
 	if s == nil {
 		return
 	}
 	s.stats.Retrying = true
 	s.stats.RetryCount = retryCount
+	s.stats.RetryReason = reason
+	s.stats.RetryDelay = delay
 }
 
 func (s *loopIterationState) markFinal() {
@@ -257,7 +273,11 @@ func (o *iterationObserver) finish(err error, stats loopIterationStats) {
 		attribute.Int("loop.tool_error_count", stats.ToolErrorCount),
 	}
 	if stats.Retrying {
-		attrs = append(attrs, attribute.Bool("loop.retrying", true))
+		attrs = append(attrs,
+			attribute.Bool("loop.retrying", true),
+			attribute.String("loop.retry_reason", stats.RetryReason),
+			attribute.Int64("loop.retry_delay_ms", stats.RetryDelay.Milliseconds()),
+		)
 	}
 	if stats.Final {
 		attrs = append(attrs, attribute.Bool("loop.final_iteration", true))

--- a/loop/loop_obs_internal_test.go
+++ b/loop/loop_obs_internal_test.go
@@ -28,6 +28,28 @@ func (f toolResponseProcessorFunc) Process(call ai.ToolCall, response *ToolRespo
 	return f(call, response)
 }
 
+func TestLoopRunSpanUsesRetryPolicyLimit(t *testing.T) {
+	recorder := obstest.Install(t)
+	l := &Loop{RetryCount: 3, RetryPolicy: &RetryPolicy{MaxRetries: 0}}
+
+	_, state := newLoopRunState(t.Context(), l)
+	state.finish()
+
+	var runSpan sdktrace.ReadOnlySpan
+	for _, span := range recorder.Ended() {
+		if span.Name() == "loop.run" {
+			runSpan = span
+			break
+		}
+	}
+	if runSpan == nil {
+		t.Fatal("loop run span was not recorded")
+	}
+	if got := obstest.Attributes(runSpan)["loop.retry_limit"].AsInt64(); got != 0 {
+		t.Fatalf("loop.retry_limit = %d, want 0", got)
+	}
+}
+
 func (t observedTestTool) Name() string              { return t.name }
 func (t observedTestTool) Description() string       { return "Test tool." }
 func (t observedTestTool) Params() ai.ToolParameters { return NewEchoTool().Params() }

--- a/loop/loop_obs_internal_test.go
+++ b/loop/loop_obs_internal_test.go
@@ -30,7 +30,7 @@ func (f toolResponseProcessorFunc) Process(call ai.ToolCall, response *ToolRespo
 
 func TestLoopRunSpanUsesRetryPolicyLimit(t *testing.T) {
 	recorder := obstest.Install(t)
-	l := &Loop{RetryCount: 3, RetryPolicy: &RetryPolicy{MaxRetries: 0}}
+	l := &Loop{RetryPolicy: &RetryPolicy{MaxRetries: 0}}
 
 	_, state := newLoopRunState(t.Context(), l)
 	state.finish()

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -1020,6 +1020,47 @@ func TestLoopNonRetryablePolicyErrorIsNotReportedAsRetryExhaustion(t *testing.T)
 	}
 }
 
+func TestLoopPolicyWithNoRetriesReturnsNonRetryableProviderError(t *testing.T) {
+	t.Parallel()
+
+	providerErr := &ai.ProviderError{Kind: ai.ProviderErrorInvalidRequest, Err: errors.New("bad request")}
+	model := &scriptedStreamModel{sequences: [][]ai.Token{{{Err: providerErr}}}}
+	l := loop.New(model, nil, testPromptBuilder(), nil)
+	l.MaxLoopIterations = 1
+	l.RetryPolicy = &loop.RetryPolicy{MaxRetries: 0}
+
+	err := loopError(collectLoopEvents(t, l, context.Background()))
+	if errors.Is(err, loop.ErrMaxRetries) {
+		t.Fatalf("error = %v, must not report retry exhaustion", err)
+	}
+	var got *ai.ProviderError
+	if !errors.As(err, &got) || got != providerErr {
+		t.Fatalf("error = %v, want original provider error", err)
+	}
+}
+
+func TestLoopPolicyReturnsNonRetryableErrorAfterBudgetIsConsumed(t *testing.T) {
+	t.Parallel()
+
+	providerErr := &ai.ProviderError{Kind: ai.ProviderErrorAuthentication, Err: errors.New("invalid credentials")}
+	model := &scriptedStreamModel{sequences: [][]ai.Token{
+		{{Err: &ai.ProviderError{Kind: ai.ProviderErrorTransient}}},
+		{{Err: providerErr}},
+	}}
+	l := loop.New(model, nil, testPromptBuilder(), nil)
+	l.MaxLoopIterations = 1
+	l.RetryPolicy = &loop.RetryPolicy{MaxRetries: 1}
+
+	err := loopError(collectLoopEvents(t, l, context.Background()))
+	if errors.Is(err, loop.ErrMaxRetries) {
+		t.Fatalf("error = %v, must not report retry exhaustion", err)
+	}
+	var got *ai.ProviderError
+	if !errors.As(err, &got) || got != providerErr {
+		t.Fatalf("error = %v, want original provider error", err)
+	}
+}
+
 func TestLoopStreamErrorsIncludeAttemptMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -44,6 +44,11 @@ type countingPromptBuilder struct {
 	count atomic.Int32
 }
 
+type deadlineRecordingPromptBuilder struct {
+	stubPromptBuilder
+	hasDeadline atomic.Bool
+}
+
 type failingToolResponseProcessor struct {
 	err error
 }
@@ -84,6 +89,20 @@ func (b *countingPromptBuilder) BuildContext(ctx context.Context) ([]gaictx.Part
 func (b *countingPromptBuilder) BuildPrompt(ctx context.Context, conv gaictx.Conversation) (string, error) {
 	count := b.count.Add(1)
 	return fmt.Sprintf("prompt-%d", count), nil
+}
+
+func (b *deadlineRecordingPromptBuilder) BuildPrompt(ctx context.Context, conv gaictx.Conversation) (string, error) {
+	_, hasDeadline := ctx.Deadline()
+	b.hasDeadline.Store(hasDeadline)
+	return b.stubPromptBuilder.BuildPrompt(ctx, conv)
+}
+
+func (b *deadlineRecordingPromptBuilder) BuildRequest(ctx context.Context, conv gaictx.Conversation) (string, []ai.RequestMessage, error) {
+	prompt, err := b.BuildPrompt(ctx, conv)
+	if err != nil {
+		return "", nil, err
+	}
+	return prompt, []ai.RequestMessage{{Role: ai.RequestMessageRoleUser, Text: prompt}}, nil
 }
 
 func (b *countingPromptBuilder) Input() gaictx.PromptInput {
@@ -702,6 +721,23 @@ func TestLoopRetriesDoNotConsumeIterations(t *testing.T) {
 	}
 	if l.Iterations[0].UserMessage == nil {
 		t.Fatal("expected completed first iteration to retain user message")
+	}
+}
+
+func TestLoopAttemptTimeoutDoesNotApplyToPromptConstruction(t *testing.T) {
+	t.Parallel()
+
+	model := &scriptedStreamModel{sequences: [][]ai.Token{{{Type: ai.TokenTypeText, Data: []byte("done")}}}}
+	promptBuilder := &deadlineRecordingPromptBuilder{stubPromptBuilder: stubPromptBuilder{userPrompt: "user"}}
+	l := loop.New(model, nil, promptBuilder, nil)
+	l.MaxLoopIterations = 1
+	l.RetryPolicy = &loop.RetryPolicy{MaxRetries: 1, AttemptTimeout: time.Second}
+
+	if err := loopError(collectLoopEvents(t, l, context.Background())); err != nil {
+		t.Fatalf("unexpected loop error: %v", err)
+	}
+	if promptBuilder.hasDeadline.Load() {
+		t.Fatal("prompt construction must not receive the model attempt deadline")
 	}
 }
 

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -542,7 +542,7 @@ func TestLoop(t *testing.T) {
 			name: "Tool call with error",
 			iterations: []mocks.MockModelResponse{
 				{Res: ai.AIResponse{Text: `{"id":"call-1","type":"function","name":"echo","arguments":{"text":"test"}}`}, Err: nil},
-				{Res: ai.AIResponse{Text: `{"id":"call-2","type":"function","name":"echo","arguments":{"text":"second test"}}`}, Err: errors.New("tool execution failed")},
+				{Res: ai.AIResponse{Text: `{"id":"call-2","type":"function","name":"echo","arguments":{"text":"second test"}}`}, Err: &ai.ProviderError{Kind: ai.ProviderErrorTransient, Err: errors.New("tool execution failed")}},
 				{Res: ai.AIResponse{Text: `{"id":"call-3","type":"function","name":"echo","arguments":{"text":"third test"}}`}, Err: nil},
 				{Res: ai.AIResponse{Text: "How are you?"}, Err: nil},
 			},
@@ -561,6 +561,7 @@ func TestLoop(t *testing.T) {
 			tools := []loop.Tool{loop.NewEchoTool()}
 			l := loop.New(wrapStreamModel{Model: model}, tools, testPromptBuilder(), nil)
 			l.MaxLoopIterations = tt.maxIterations
+			l.RetryPolicy = &loop.RetryPolicy{MaxRetries: 1}
 
 			err := loopError(collectLoopEvents(t, l, context.Background()))
 
@@ -745,15 +746,15 @@ func TestLoopRetriesDoNotConsumeIterations(t *testing.T) {
 
 	model := &scriptedStreamModel{
 		sequences: [][]ai.Token{
-			{{Err: errors.New("temporary 1")}},
-			{{Err: errors.New("temporary 2")}},
-			{{Err: errors.New("temporary 3")}},
+			{{Err: &ai.ProviderError{Kind: ai.ProviderErrorTransient, Err: errors.New("temporary 1")}}},
+			{{Err: &ai.ProviderError{Kind: ai.ProviderErrorTransient, Err: errors.New("temporary 2")}}},
+			{{Err: &ai.ProviderError{Kind: ai.ProviderErrorTransient, Err: errors.New("temporary 3")}}},
 			{{Type: ai.TokenTypeText, Data: []byte("done")}},
 		},
 	}
 	l := loop.New(model, []loop.Tool{loop.NewEchoTool()}, testPromptBuilder(), nil)
 	l.MaxLoopIterations = 1
-	l.RetryCount = 3
+	l.RetryPolicy = &loop.RetryPolicy{MaxRetries: 3}
 
 	events := collectLoopEvents(t, l, context.Background())
 	if err := loopError(events); err != nil {
@@ -795,6 +796,25 @@ func TestLoopRetriesDoNotConsumeIterations(t *testing.T) {
 	}
 	if l.Iterations[0].UserMessage == nil {
 		t.Fatal("expected completed first iteration to retain user message")
+	}
+}
+
+func TestLoopWithoutRetryPolicyDoesNotRetry(t *testing.T) {
+	t.Parallel()
+
+	model := &scriptedStreamModel{sequences: [][]ai.Token{
+		{{Err: errors.New("temporary stream failure")}},
+		{{Type: ai.TokenTypeText, Data: []byte("must not be requested")}},
+	}}
+	l := loop.New(model, nil, testPromptBuilder(), nil)
+	l.MaxLoopIterations = 1
+
+	err := loopError(collectLoopEvents(t, l, context.Background()))
+	if !errors.Is(err, loop.ErrMaxRetries) {
+		t.Fatalf("error = %v, want ErrMaxRetries", err)
+	}
+	if got := len(model.Requests()); got != 1 {
+		t.Fatalf("model attempts = %d, want 1 without a retry policy", got)
 	}
 }
 
@@ -987,7 +1007,6 @@ func TestLoopTerminalRetryErrorReportsPolicyLimit(t *testing.T) {
 	}
 	l := loop.New(model, nil, testPromptBuilder(), nil)
 	l.MaxLoopIterations = 1
-	l.RetryCount = 3
 	l.RetryPolicy = &loop.RetryPolicy{MaxRetries: 0}
 
 	err := loopError(collectLoopEvents(t, l, context.Background()))
@@ -1071,7 +1090,6 @@ func TestLoopStreamErrorsIncludeAttemptMetadata(t *testing.T) {
 	}
 	l := loop.New(model, []loop.Tool{loop.NewEchoTool()}, testPromptBuilder(), nil)
 	l.MaxLoopIterations = 1
-	l.RetryCount = 0
 
 	events := collectLoopEvents(t, l, context.Background())
 	err := loopError(events)
@@ -1106,7 +1124,6 @@ func TestLoopTerminalStreamErrorIncludesPartialAttemptIteration(t *testing.T) {
 	}
 	l := loop.New(model, []loop.Tool{loop.NewEchoTool()}, testPromptBuilder(), nil)
 	l.MaxLoopIterations = 1
-	l.RetryCount = 0
 
 	events := collectLoopEvents(t, l, context.Background())
 	err := loopError(events)
@@ -1139,7 +1156,7 @@ func TestLoopRetryStatusMarksPartialTokensDiscardable(t *testing.T) {
 		sequences: [][]ai.Token{
 			{
 				{Type: ai.TokenTypeText, Data: []byte("partial")},
-				{Err: errors.New("temporary")},
+				{Err: &ai.ProviderError{Kind: ai.ProviderErrorTransient, Err: errors.New("temporary")}},
 			},
 			{
 				{Type: ai.TokenTypeText, Data: []byte("final")},
@@ -1148,7 +1165,7 @@ func TestLoopRetryStatusMarksPartialTokensDiscardable(t *testing.T) {
 	}
 	l := loop.New(model, []loop.Tool{loop.NewEchoTool()}, testPromptBuilder(), nil)
 	l.MaxLoopIterations = 1
-	l.RetryCount = 1
+	l.RetryPolicy = &loop.RetryPolicy{MaxRetries: 1}
 
 	events := collectLoopEvents(t, l, context.Background())
 	if err := loopError(events); err != nil {
@@ -1193,7 +1210,6 @@ func TestLoopDoesNotRetryCanceledStream(t *testing.T) {
 	}
 	l := loop.New(model, []loop.Tool{loop.NewEchoTool()}, testPromptBuilder(), nil)
 	l.MaxLoopIterations = 1
-	l.RetryCount = 3
 
 	events := collectLoopEvents(t, l, context.Background())
 	if err := loopError(events); err != nil {

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -802,16 +802,26 @@ func TestLoopRetriesDoNotConsumeIterations(t *testing.T) {
 func TestLoopWithoutRetryPolicyDoesNotRetry(t *testing.T) {
 	t.Parallel()
 
+	streamErr := errors.New("temporary stream failure")
 	model := &scriptedStreamModel{sequences: [][]ai.Token{
-		{{Err: errors.New("temporary stream failure")}},
+		{{Err: streamErr}},
 		{{Type: ai.TokenTypeText, Data: []byte("must not be requested")}},
 	}}
 	l := loop.New(model, nil, testPromptBuilder(), nil)
 	l.MaxLoopIterations = 1
 
-	err := loopError(collectLoopEvents(t, l, context.Background()))
-	if !errors.Is(err, loop.ErrMaxRetries) {
-		t.Fatalf("error = %v, want ErrMaxRetries", err)
+	events := collectLoopEvents(t, l, context.Background())
+	err := loopError(events)
+	if !errors.Is(err, streamErr) {
+		t.Fatalf("error = %v, want original stream error", err)
+	}
+	if errors.Is(err, loop.ErrMaxRetries) {
+		t.Fatalf("error = %v, must not report retry exhaustion without a policy", err)
+	}
+	for _, event := range events {
+		if event.Type == loop.EventRetry {
+			t.Fatal("nil retry policy must not emit EventRetry")
+		}
 	}
 	if got := len(model.Requests()); got != 1 {
 		t.Fatalf("model attempts = %d, want 1 without a retry policy", got)
@@ -1083,9 +1093,10 @@ func TestLoopPolicyReturnsNonRetryableErrorAfterBudgetIsConsumed(t *testing.T) {
 func TestLoopStreamErrorsIncludeAttemptMetadata(t *testing.T) {
 	t.Parallel()
 
+	fatalErr := errors.New("fatal stream error")
 	model := &scriptedStreamModel{
 		sequences: [][]ai.Token{
-			{{Err: errors.New("fatal stream error")}},
+			{{Err: fatalErr}},
 		},
 	}
 	l := loop.New(model, []loop.Tool{loop.NewEchoTool()}, testPromptBuilder(), nil)
@@ -1093,8 +1104,8 @@ func TestLoopStreamErrorsIncludeAttemptMetadata(t *testing.T) {
 
 	events := collectLoopEvents(t, l, context.Background())
 	err := loopError(events)
-	if !errors.Is(err, loop.ErrMaxRetries) {
-		t.Fatalf("error = %v, want ErrMaxRetries", err)
+	if !errors.Is(err, fatalErr) || errors.Is(err, loop.ErrMaxRetries) {
+		t.Fatalf("error = %v, want original non-retry error", err)
 	}
 	errorEvents := loopEventsOfType(events, loop.EventError)
 	if len(errorEvents) != 1 {
@@ -1106,19 +1117,20 @@ func TestLoopStreamErrorsIncludeAttemptMetadata(t *testing.T) {
 	if errorEvents[0].Iteration == nil || errorEvents[0].Iteration.UserMessage == nil {
 		t.Fatalf("expected failed attempt snapshot to retain user message, got %#v", errorEvents[0].Iteration)
 	}
-	if strings.Count(errorEvents[0].Err.Error(), loop.ErrMaxRetries.Error()) != 1 {
-		t.Fatalf("expected terminal error once, got %q", errorEvents[0].Err)
+	if !errors.Is(errorEvents[0].Err, fatalErr) || errors.Is(errorEvents[0].Err, loop.ErrMaxRetries) {
+		t.Fatalf("expected original terminal error, got %q", errorEvents[0].Err)
 	}
 }
 
 func TestLoopTerminalStreamErrorIncludesPartialAttemptIteration(t *testing.T) {
 	t.Parallel()
 
+	fatalErr := errors.New("fatal stream error")
 	model := &scriptedStreamModel{
 		sequences: [][]ai.Token{
 			{
 				{Type: ai.TokenTypeText, Data: []byte("partial")},
-				{Err: errors.New("fatal stream error")},
+				{Err: fatalErr},
 			},
 		},
 	}
@@ -1127,8 +1139,8 @@ func TestLoopTerminalStreamErrorIncludesPartialAttemptIteration(t *testing.T) {
 
 	events := collectLoopEvents(t, l, context.Background())
 	err := loopError(events)
-	if !errors.Is(err, loop.ErrMaxRetries) {
-		t.Fatalf("error = %v, want ErrMaxRetries", err)
+	if !errors.Is(err, fatalErr) || errors.Is(err, loop.ErrMaxRetries) {
+		t.Fatalf("error = %v, want original non-retry error", err)
 	}
 	errorEvents := loopEventsOfType(events, loop.EventError)
 	if len(errorEvents) != 1 {

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -30,10 +30,13 @@ func (m wrapStreamModel) GenerateStream(ctx context.Context, req ai.AIRequest) <
 }
 
 type scriptedStreamModel struct {
-	sequences [][]ai.Token
-	idx       int
-	mu        sync.Mutex
-	requests  []ai.AIRequest
+	sequences     [][]ai.Token
+	delays        []time.Duration
+	ignoreContext bool
+	idx           int
+	mu            sync.Mutex
+	requests      []ai.AIRequest
+	requestTimes  []time.Time
 }
 
 type cancelAfterTokenModel struct {
@@ -235,15 +238,27 @@ func (m *scriptedStreamModel) GenerateStream(ctx context.Context, req ai.AIReque
 		defer close(out)
 		m.mu.Lock()
 		m.requests = append(m.requests, req)
+		m.requestTimes = append(m.requestTimes, time.Now())
 		m.mu.Unlock()
 
 		if m.idx >= len(m.sequences) {
 			return
 		}
 		seq := m.sequences[m.idx]
+		var delay time.Duration
+		if m.idx < len(m.delays) {
+			delay = m.delays[m.idx]
+		}
 		m.idx++
+		if delay > 0 {
+			time.Sleep(delay)
+		}
 
 		for _, tok := range seq {
+			if m.ignoreContext {
+				out <- tok
+				continue
+			}
 			select {
 			case <-ctx.Done():
 				return
@@ -270,6 +285,15 @@ func (m *scriptedStreamModel) Requests() []ai.AIRequest {
 	requests := make([]ai.AIRequest, len(m.requests))
 	copy(requests, m.requests)
 	return requests
+}
+
+func (m *scriptedStreamModel) RequestTimes() []time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	times := make([]time.Time, len(m.requestTimes))
+	copy(times, m.requestTimes)
+	return times
 }
 
 func (m *cancelAfterTokenModel) Name() string {
@@ -738,6 +762,38 @@ func TestLoopAttemptTimeoutDoesNotApplyToPromptConstruction(t *testing.T) {
 	}
 	if promptBuilder.hasDeadline.Load() {
 		t.Fatal("prompt construction must not receive the model attempt deadline")
+	}
+}
+
+func TestLoopAttemptTimeoutPreservesProviderRetryAfter(t *testing.T) {
+	t.Parallel()
+
+	retryAfter := 40 * time.Millisecond
+	model := &scriptedStreamModel{
+		sequences: [][]ai.Token{
+			{{Err: &ai.ProviderError{Kind: ai.ProviderErrorTransient, RetryAfter: retryAfter}}},
+			{{Type: ai.TokenTypeText, Data: []byte("done")}},
+		},
+		delays:        []time.Duration{5 * time.Millisecond},
+		ignoreContext: true,
+	}
+	l := loop.New(model, nil, testPromptBuilder(), nil)
+	l.MaxLoopIterations = 1
+	l.RetryPolicy = &loop.RetryPolicy{
+		MaxRetries:        1,
+		AttemptTimeout:    time.Millisecond,
+		RespectRetryAfter: true,
+	}
+
+	if err := loopError(collectLoopEvents(t, l, context.Background())); err != nil {
+		t.Fatalf("unexpected loop error: %v", err)
+	}
+	times := model.RequestTimes()
+	if len(times) != 2 {
+		t.Fatalf("expected 2 model attempts, got %d", len(times))
+	}
+	if elapsed := times[1].Sub(times[0]); elapsed < retryAfter {
+		t.Fatalf("retry began after %s, want at least provider RetryAfter %s", elapsed, retryAfter)
 	}
 }
 

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -52,6 +52,10 @@ type deadlineRecordingPromptBuilder struct {
 	hasDeadline atomic.Bool
 }
 
+type deadlineRecordingTool struct {
+	hasDeadline atomic.Bool
+}
+
 type failingToolResponseProcessor struct {
 	err error
 }
@@ -98,6 +102,19 @@ func (b *deadlineRecordingPromptBuilder) BuildPrompt(ctx context.Context, conv g
 	_, hasDeadline := ctx.Deadline()
 	b.hasDeadline.Store(hasDeadline)
 	return b.stubPromptBuilder.BuildPrompt(ctx, conv)
+}
+
+func (t *deadlineRecordingTool) Name() string { return "record-deadline" }
+func (t *deadlineRecordingTool) Description() string {
+	return "Records whether its context has a deadline."
+}
+func (t *deadlineRecordingTool) Params() ai.ToolParameters {
+	return loop.NewEchoTool().Params()
+}
+func (t *deadlineRecordingTool) Function(ctx context.Context, _ *ai.ToolCall) *loop.ToolResponse {
+	_, hasDeadline := ctx.Deadline()
+	t.hasDeadline.Store(hasDeadline)
+	return loop.NewToolSuccess("ok")
 }
 
 func (b *deadlineRecordingPromptBuilder) BuildRequest(ctx context.Context, conv gaictx.Conversation) (string, []ai.RequestMessage, error) {
@@ -762,6 +779,34 @@ func TestLoopAttemptTimeoutDoesNotApplyToPromptConstruction(t *testing.T) {
 	}
 	if promptBuilder.hasDeadline.Load() {
 		t.Fatal("prompt construction must not receive the model attempt deadline")
+	}
+}
+
+func TestLoopAttemptTimeoutDoesNotApplyToToolExecution(t *testing.T) {
+	t.Parallel()
+
+	tool := &deadlineRecordingTool{}
+	model := &scriptedStreamModel{sequences: [][]ai.Token{
+		{{
+			Type: ai.TokenTypeToolCall,
+			ToolCall: &ai.ToolCall{
+				ID:   "call-1",
+				Type: "function",
+				Name: "record-deadline",
+				Args: json.RawMessage(`{"text":"payload"}`),
+			},
+		}},
+		{{Type: ai.TokenTypeText, Data: []byte("done")}},
+	}}
+	l := loop.New(model, []loop.Tool{tool}, testPromptBuilder(), nil)
+	l.MaxLoopIterations = 2
+	l.RetryPolicy = &loop.RetryPolicy{MaxRetries: 1, AttemptTimeout: time.Second}
+
+	if err := loopError(collectLoopEvents(t, l, context.Background())); err != nil {
+		t.Fatalf("unexpected loop error: %v", err)
+	}
+	if tool.hasDeadline.Load() {
+		t.Fatal("tool execution must not receive the model attempt deadline")
 	}
 }
 

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -797,6 +797,26 @@ func TestLoopAttemptTimeoutPreservesProviderRetryAfter(t *testing.T) {
 	}
 }
 
+func TestLoopTerminalRetryErrorReportsPolicyLimit(t *testing.T) {
+	t.Parallel()
+
+	model := &scriptedStreamModel{
+		sequences: [][]ai.Token{{{Err: &ai.ProviderError{Kind: ai.ProviderErrorTransient}}}},
+	}
+	l := loop.New(model, nil, testPromptBuilder(), nil)
+	l.MaxLoopIterations = 1
+	l.RetryCount = 3
+	l.RetryPolicy = &loop.RetryPolicy{MaxRetries: 0}
+
+	err := loopError(collectLoopEvents(t, l, context.Background()))
+	if !errors.Is(err, loop.ErrMaxRetries) {
+		t.Fatalf("error = %v, want ErrMaxRetries", err)
+	}
+	if !strings.Contains(err.Error(), "limit=0") {
+		t.Fatalf("error = %q, want active policy limit", err)
+	}
+}
+
 func TestLoopStreamErrorsIncludeAttemptMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -43,6 +43,11 @@ type cancelAfterTokenModel struct {
 	cancel context.CancelFunc
 }
 
+type retryCancellationModel struct {
+	attemptCanceled chan struct{}
+	calls           atomic.Int32
+}
+
 type countingPromptBuilder struct {
 	count atomic.Int32
 }
@@ -336,6 +341,34 @@ func (m *cancelAfterTokenModel) Close() error {
 }
 
 func (m *cancelAfterTokenModel) Tokenizer() ai.Tokenizer {
+	return &mocks.MockTokenizer{}
+}
+
+func (m *retryCancellationModel) Name() string { return "retry-cancellation-model" }
+
+func (m *retryCancellationModel) Generate(context.Context, ai.AIRequest) (*ai.AIResponse, error) {
+	return &ai.AIResponse{}, nil
+}
+
+func (m *retryCancellationModel) GenerateStream(ctx context.Context, _ ai.AIRequest) <-chan ai.Token {
+	out := make(chan ai.Token)
+	attempt := m.calls.Add(1)
+	go func() {
+		defer close(out)
+		if attempt == 1 {
+			out <- ai.Token{Err: &ai.ProviderError{Kind: ai.ProviderErrorTransient}}
+			<-ctx.Done()
+			close(m.attemptCanceled)
+			return
+		}
+		out <- ai.Token{Type: ai.TokenTypeText, Data: []byte("done")}
+	}()
+	return out
+}
+
+func (m *retryCancellationModel) Close() error { return nil }
+
+func (m *retryCancellationModel) Tokenizer() ai.Tokenizer {
 	return &mocks.MockTokenizer{}
 }
 
@@ -868,6 +901,31 @@ func TestLoopRetryUsesInjectedWait(t *testing.T) {
 	}
 	if waited != time.Hour {
 		t.Fatalf("waited %s, want %s", waited, time.Hour)
+	}
+}
+
+func TestLoopCancelsFailedAttemptBeforeRetryBackoff(t *testing.T) {
+	model := &retryCancellationModel{attemptCanceled: make(chan struct{})}
+	l := loop.New(model, nil, testPromptBuilder(), nil)
+	l.MaxLoopIterations = 1
+	l.RetryPolicy = &loop.RetryPolicy{
+		MaxRetries:     1,
+		InitialBackoff: time.Hour,
+		Wait: func(_ context.Context, _ time.Duration) error {
+			select {
+			case <-model.attemptCanceled:
+				return nil
+			case <-time.After(100 * time.Millisecond):
+				return errors.New("model attempt was still active during retry backoff")
+			}
+		},
+	}
+
+	if err := loopError(collectLoopEvents(t, l, context.Background())); err != nil {
+		t.Fatalf("unexpected loop error: %v", err)
+	}
+	if calls := model.calls.Load(); calls != 2 {
+		t.Fatalf("model attempts = %d, want 2", calls)
 	}
 }
 

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -797,6 +797,35 @@ func TestLoopAttemptTimeoutPreservesProviderRetryAfter(t *testing.T) {
 	}
 }
 
+func TestLoopRetryUsesInjectedWait(t *testing.T) {
+	t.Parallel()
+
+	model := &scriptedStreamModel{
+		sequences: [][]ai.Token{
+			{{Err: &ai.ProviderError{Kind: ai.ProviderErrorTransient}}},
+			{{Type: ai.TokenTypeText, Data: []byte("done")}},
+		},
+	}
+	var waited time.Duration
+	l := loop.New(model, nil, testPromptBuilder(), nil)
+	l.MaxLoopIterations = 1
+	l.RetryPolicy = &loop.RetryPolicy{
+		MaxRetries:     1,
+		InitialBackoff: time.Hour,
+		Wait: func(_ context.Context, delay time.Duration) error {
+			waited = delay
+			return nil
+		},
+	}
+
+	if err := loopError(collectLoopEvents(t, l, context.Background())); err != nil {
+		t.Fatalf("unexpected loop error: %v", err)
+	}
+	if waited != time.Hour {
+		t.Fatalf("waited %s, want %s", waited, time.Hour)
+	}
+}
+
 func TestLoopTerminalRetryErrorReportsPolicyLimit(t *testing.T) {
 	t.Parallel()
 

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -875,6 +875,56 @@ func TestLoopAttemptTimeoutPreservesProviderRetryAfter(t *testing.T) {
 	}
 }
 
+func TestLoopRetryObservabilityReportsClassificationAndDelay(t *testing.T) {
+	previousProvider := otel.GetTracerProvider()
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(provider)
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+		otel.SetTracerProvider(previousProvider)
+	})
+
+	retryDelay := 7 * time.Millisecond
+	model := &scriptedStreamModel{sequences: [][]ai.Token{
+		{{Err: &ai.ProviderError{Kind: ai.ProviderErrorRateLimited}}},
+		{{Type: ai.TokenTypeText, Data: []byte("done")}},
+	}}
+	l := loop.New(model, nil, testPromptBuilder(), nil)
+	l.MaxLoopIterations = 1
+	l.RetryPolicy = &loop.RetryPolicy{
+		MaxRetries:     1,
+		InitialBackoff: retryDelay,
+		Wait:           func(context.Context, time.Duration) error { return nil },
+	}
+
+	events := collectLoopEvents(t, l, context.Background())
+	if err := loopError(events); err != nil {
+		t.Fatalf("unexpected loop error: %v", err)
+	}
+	retries := loopEventsOfType(events, loop.EventRetry)
+	if len(retries) != 1 {
+		t.Fatalf("retry events = %d, want 1", len(retries))
+	}
+	if retries[0].RetryReason != "rate_limited" || retries[0].RetryDelay != retryDelay {
+		t.Fatalf("retry event observability = %#v, want reason rate_limited and delay %s", retries[0], retryDelay)
+	}
+
+	for _, span := range recorder.Ended() {
+		if span.Name() != "loop.iteration" {
+			continue
+		}
+		attributes := map[string]any{}
+		for _, attribute := range span.Attributes() {
+			attributes[string(attribute.Key)] = attribute.Value.AsInterface()
+		}
+		if attributes["loop.retry_reason"] == "rate_limited" && attributes["loop.retry_delay_ms"] == int64(retryDelay/time.Millisecond) {
+			return
+		}
+	}
+	t.Fatalf("retrying iteration span missing classification or delay: %#v", recorder.Ended())
+}
+
 func TestLoopRetryUsesInjectedWait(t *testing.T) {
 	t.Parallel()
 

--- a/loop/loop_test.go
+++ b/loop/loop_test.go
@@ -846,6 +846,27 @@ func TestLoopTerminalRetryErrorReportsPolicyLimit(t *testing.T) {
 	}
 }
 
+func TestLoopNonRetryablePolicyErrorIsNotReportedAsRetryExhaustion(t *testing.T) {
+	t.Parallel()
+
+	providerErr := &ai.ProviderError{Kind: ai.ProviderErrorInvalidRequest, Err: errors.New("bad request")}
+	model := &scriptedStreamModel{
+		sequences: [][]ai.Token{{{Err: providerErr}}},
+	}
+	l := loop.New(model, nil, testPromptBuilder(), nil)
+	l.MaxLoopIterations = 1
+	l.RetryPolicy = &loop.RetryPolicy{MaxRetries: 3}
+
+	err := loopError(collectLoopEvents(t, l, context.Background()))
+	if errors.Is(err, loop.ErrMaxRetries) {
+		t.Fatalf("error = %v, must not report retry exhaustion", err)
+	}
+	var got *ai.ProviderError
+	if !errors.As(err, &got) || got != providerErr {
+		t.Fatalf("error = %v, want original provider error", err)
+	}
+}
+
 func TestLoopStreamErrorsIncludeAttemptMetadata(t *testing.T) {
 	t.Parallel()
 

--- a/loop/retry_policy.go
+++ b/loop/retry_policy.go
@@ -54,6 +54,8 @@ func (p RetryPolicy) Validate() error {
 		return errors.New("retry policy AttemptTimeout must be non-negative")
 	case p.TotalTimeout < 0:
 		return errors.New("retry policy TotalTimeout must be non-negative")
+	case math.IsNaN(p.Multiplier) || math.IsInf(p.Multiplier, 0):
+		return errors.New("retry policy Multiplier must be finite")
 	case math.IsNaN(p.Jitter) || p.Jitter < 0 || p.Jitter > 1:
 		return errors.New("retry policy Jitter must be within [0, 1]")
 	}
@@ -103,10 +105,7 @@ func (p RetryPolicy) Backoff(retries int, err error) time.Duration {
 		m = 2
 	}
 	for range retries {
-		d = time.Duration(float64(d) * m)
-	}
-	if p.MaxBackoff > 0 && d > p.MaxBackoff {
-		d = p.MaxBackoff
+		d = cappedDuration(float64(d)*m, p.MaxBackoff)
 	}
 	if p.Jitter > 0 {
 		source := p.JitterSource
@@ -120,12 +119,22 @@ func (p RetryPolicy) Backoff(retries int, err error) time.Duration {
 		case jitter >= 1:
 			jitter = math.Nextafter(1, 0)
 		}
-		d = time.Duration(float64(d) * (1 - p.Jitter + jitter*2*p.Jitter))
-	}
-	if p.MaxBackoff > 0 && d > p.MaxBackoff {
-		d = p.MaxBackoff
+		d = cappedDuration(float64(d)*(1-p.Jitter+jitter*2*p.Jitter), p.MaxBackoff)
 	}
 	return d
+}
+
+func cappedDuration(value float64, maximum time.Duration) time.Duration {
+	if value <= 0 || math.IsNaN(value) {
+		return 0
+	}
+	if maximum <= 0 {
+		maximum = time.Duration(math.MaxInt64)
+	}
+	if value >= float64(maximum) {
+		return maximum
+	}
+	return time.Duration(value)
 }
 
 func (p RetryPolicy) wait(ctx context.Context, delay time.Duration) error {

--- a/loop/retry_policy.go
+++ b/loop/retry_policy.go
@@ -20,8 +20,8 @@ type attemptTimeoutError struct{}
 func (attemptTimeoutError) Error() string { return "retry attempt timeout" }
 func (attemptTimeoutError) Unwrap() error { return context.DeadlineExceeded }
 
-// RetryPolicy controls classified model-generation retries. A non-nil policy
-// takes precedence over RetryCount; MaxRetries: 0 explicitly disables retries.
+// RetryPolicy controls classified model-generation retries. MaxRetries: 0
+// explicitly disables retries.
 type RetryPolicy struct {
 	MaxRetries     int
 	InitialBackoff time.Duration

--- a/loop/retry_policy.go
+++ b/loop/retry_policy.go
@@ -61,7 +61,15 @@ func (p RetryPolicy) Validate() error {
 }
 
 func (p RetryPolicy) ShouldRetry(retries int, err error) bool {
-	if retries >= p.MaxRetries || err == nil || errors.Is(err, context.Canceled) {
+	return p.hasRetryBudget(retries) && p.isRetryable(err)
+}
+
+func (p RetryPolicy) hasRetryBudget(retries int) bool {
+	return retries < p.MaxRetries
+}
+
+func (p RetryPolicy) isRetryable(err error) bool {
+	if err == nil || errors.Is(err, context.Canceled) {
 		return false
 	}
 	if errors.Is(err, ErrAttemptTimeout) {

--- a/loop/retry_policy.go
+++ b/loop/retry_policy.go
@@ -1,0 +1,75 @@
+package loop
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"time"
+
+	"github.com/lace-ai/gai/ai"
+)
+
+// ErrAttemptTimeout identifies a deadline created by RetryPolicy, rather than
+// a caller or total-run deadline. It wraps context.DeadlineExceeded so callers
+// can retain standard context handling while policy can retry it safely.
+var ErrAttemptTimeout = attemptTimeoutError{}
+
+type attemptTimeoutError struct{}
+
+func (attemptTimeoutError) Error() string { return "retry attempt timeout" }
+func (attemptTimeoutError) Unwrap() error { return context.DeadlineExceeded }
+
+// RetryPolicy controls classified model-generation retries. A non-nil policy
+// takes precedence over RetryCount; MaxRetries: 0 explicitly disables retries.
+type RetryPolicy struct {
+	MaxRetries        int
+	InitialBackoff    time.Duration
+	MaxBackoff        time.Duration
+	Multiplier        float64
+	Jitter            float64
+	RespectRetryAfter bool
+	AttemptTimeout    time.Duration
+	TotalTimeout      time.Duration
+}
+
+func (p RetryPolicy) ShouldRetry(retries int, err error) bool {
+	if retries >= p.MaxRetries || err == nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, ErrAttemptTimeout) {
+		return true
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	var provider *ai.ProviderError
+	if !errors.As(err, &provider) {
+		return false
+	}
+	return provider.Kind == ai.ProviderErrorRateLimited || provider.Kind == ai.ProviderErrorTransient
+}
+
+func (p RetryPolicy) Backoff(retries int, err error) time.Duration {
+	var provider *ai.ProviderError
+	if p.RespectRetryAfter && errors.As(err, &provider) && provider.RetryAfter > 0 {
+		return provider.RetryAfter
+	}
+	d := p.InitialBackoff
+	if d <= 0 {
+		return 0
+	}
+	m := p.Multiplier
+	if m <= 0 {
+		m = 2
+	}
+	for range retries {
+		d = time.Duration(float64(d) * m)
+	}
+	if p.MaxBackoff > 0 && d > p.MaxBackoff {
+		d = p.MaxBackoff
+	}
+	if p.Jitter > 0 {
+		d = time.Duration(float64(d) * (1 - p.Jitter + rand.Float64()*2*p.Jitter))
+	}
+	return d
+}

--- a/loop/retry_policy.go
+++ b/loop/retry_policy.go
@@ -88,7 +88,11 @@ func (p RetryPolicy) isRetryable(err error) bool {
 func (p RetryPolicy) Backoff(retries int, err error) time.Duration {
 	var provider *ai.ProviderError
 	if p.RespectRetryAfter && errors.As(err, &provider) && provider.RetryAfter > 0 {
-		return provider.RetryAfter
+		d := provider.RetryAfter
+		if p.MaxBackoff > 0 && d > p.MaxBackoff {
+			d = p.MaxBackoff
+		}
+		return d
 	}
 	d := p.InitialBackoff
 	if d <= 0 {

--- a/loop/retry_policy.go
+++ b/loop/retry_policy.go
@@ -3,6 +3,7 @@ package loop
 import (
 	"context"
 	"errors"
+	"math"
 	"math/rand/v2"
 	"time"
 
@@ -26,9 +27,11 @@ type RetryPolicy struct {
 	InitialBackoff time.Duration
 	MaxBackoff     time.Duration
 	Multiplier     float64
-	Jitter         float64
+	// Jitter is the proportional randomization amount in the inclusive range [0, 1].
+	Jitter float64
 	// JitterSource supplies a value in [0, 1) when applying jitter. Nil uses
-	// math/rand/v2's default source.
+	// math/rand/v2's default source. Out-of-range source values are constrained
+	// to that range before use.
 	JitterSource func() float64
 	// Wait blocks for a retry delay or returns the context error when canceled.
 	// Nil waits using a wall-clock timer.
@@ -36,6 +39,25 @@ type RetryPolicy struct {
 	RespectRetryAfter bool
 	AttemptTimeout    time.Duration
 	TotalTimeout      time.Duration
+}
+
+// Validate verifies that RetryPolicy's public limits and durations are valid.
+func (p RetryPolicy) Validate() error {
+	switch {
+	case p.MaxRetries < 0:
+		return errors.New("retry policy MaxRetries must be non-negative")
+	case p.InitialBackoff < 0:
+		return errors.New("retry policy InitialBackoff must be non-negative")
+	case p.MaxBackoff < 0:
+		return errors.New("retry policy MaxBackoff must be non-negative")
+	case p.AttemptTimeout < 0:
+		return errors.New("retry policy AttemptTimeout must be non-negative")
+	case p.TotalTimeout < 0:
+		return errors.New("retry policy TotalTimeout must be non-negative")
+	case math.IsNaN(p.Jitter) || p.Jitter < 0 || p.Jitter > 1:
+		return errors.New("retry policy Jitter must be within [0, 1]")
+	}
+	return nil
 }
 
 func (p RetryPolicy) ShouldRetry(retries int, err error) bool {
@@ -79,7 +101,14 @@ func (p RetryPolicy) Backoff(retries int, err error) time.Duration {
 		if source == nil {
 			source = rand.Float64
 		}
-		d = time.Duration(float64(d) * (1 - p.Jitter + source()*2*p.Jitter))
+		jitter := source()
+		switch {
+		case math.IsNaN(jitter) || jitter < 0:
+			jitter = 0
+		case jitter >= 1:
+			jitter = math.Nextafter(1, 0)
+		}
+		d = time.Duration(float64(d) * (1 - p.Jitter + jitter*2*p.Jitter))
 	}
 	if p.MaxBackoff > 0 && d > p.MaxBackoff {
 		d = p.MaxBackoff

--- a/loop/retry_policy.go
+++ b/loop/retry_policy.go
@@ -71,5 +71,8 @@ func (p RetryPolicy) Backoff(retries int, err error) time.Duration {
 	if p.Jitter > 0 {
 		d = time.Duration(float64(d) * (1 - p.Jitter + rand.Float64()*2*p.Jitter))
 	}
+	if p.MaxBackoff > 0 && d > p.MaxBackoff {
+		d = p.MaxBackoff
+	}
 	return d
 }

--- a/loop/retry_policy.go
+++ b/loop/retry_policy.go
@@ -22,11 +22,17 @@ func (attemptTimeoutError) Unwrap() error { return context.DeadlineExceeded }
 // RetryPolicy controls classified model-generation retries. A non-nil policy
 // takes precedence over RetryCount; MaxRetries: 0 explicitly disables retries.
 type RetryPolicy struct {
-	MaxRetries        int
-	InitialBackoff    time.Duration
-	MaxBackoff        time.Duration
-	Multiplier        float64
-	Jitter            float64
+	MaxRetries     int
+	InitialBackoff time.Duration
+	MaxBackoff     time.Duration
+	Multiplier     float64
+	Jitter         float64
+	// JitterSource supplies a value in [0, 1) when applying jitter. Nil uses
+	// math/rand/v2's default source.
+	JitterSource func() float64
+	// Wait blocks for a retry delay or returns the context error when canceled.
+	// Nil waits using a wall-clock timer.
+	Wait              func(context.Context, time.Duration) error
 	RespectRetryAfter bool
 	AttemptTimeout    time.Duration
 	TotalTimeout      time.Duration
@@ -69,10 +75,28 @@ func (p RetryPolicy) Backoff(retries int, err error) time.Duration {
 		d = p.MaxBackoff
 	}
 	if p.Jitter > 0 {
-		d = time.Duration(float64(d) * (1 - p.Jitter + rand.Float64()*2*p.Jitter))
+		source := p.JitterSource
+		if source == nil {
+			source = rand.Float64
+		}
+		d = time.Duration(float64(d) * (1 - p.Jitter + source()*2*p.Jitter))
 	}
 	if p.MaxBackoff > 0 && d > p.MaxBackoff {
 		d = p.MaxBackoff
 	}
 	return d
+}
+
+func (p RetryPolicy) wait(ctx context.Context, delay time.Duration) error {
+	if p.Wait != nil {
+		return p.Wait(ctx, delay)
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }

--- a/loop/retry_policy.go
+++ b/loop/retry_policy.go
@@ -100,6 +100,9 @@ func (p RetryPolicy) Backoff(retries int, err error) time.Duration {
 	if d <= 0 {
 		return 0
 	}
+	if p.MaxBackoff > 0 && d > p.MaxBackoff {
+		d = p.MaxBackoff
+	}
 	m := p.Multiplier
 	if m <= 0 {
 		m = 2

--- a/loop/retry_policy_test.go
+++ b/loop/retry_policy_test.go
@@ -63,3 +63,49 @@ func TestRetryPolicyBackoffUsesInjectedJitterSource(t *testing.T) {
 		t.Fatalf("backoff = %s, want 12.5ms", backoff)
 	}
 }
+
+func TestRetryPolicyValidateRejectsInvalidPublicValues(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy loop.RetryPolicy
+	}{
+		{name: "negative retries", policy: loop.RetryPolicy{MaxRetries: -1}},
+		{name: "negative initial backoff", policy: loop.RetryPolicy{InitialBackoff: -time.Nanosecond}},
+		{name: "negative maximum backoff", policy: loop.RetryPolicy{MaxBackoff: -time.Nanosecond}},
+		{name: "negative attempt timeout", policy: loop.RetryPolicy{AttemptTimeout: -time.Nanosecond}},
+		{name: "negative total timeout", policy: loop.RetryPolicy{TotalTimeout: -time.Nanosecond}},
+		{name: "negative jitter", policy: loop.RetryPolicy{Jitter: -0.01}},
+		{name: "jitter above one", policy: loop.RetryPolicy{Jitter: 1.01}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.policy.Validate(); err == nil {
+				t.Fatal("Validate() succeeded for an invalid retry policy")
+			}
+		})
+	}
+}
+
+func TestLoopValidateRejectsInvalidRetryPolicy(t *testing.T) {
+	l := loop.New(&scriptedStreamModel{}, nil, testPromptBuilder(), nil)
+	l.RetryPolicy = &loop.RetryPolicy{Jitter: 1.01}
+
+	if err := l.Validate(); err == nil {
+		t.Fatal("Loop.Validate() succeeded with an invalid retry policy")
+	}
+}
+
+func TestRetryPolicyBackoffGuardsInjectedJitterSource(t *testing.T) {
+	policy := loop.RetryPolicy{
+		InitialBackoff: 10 * time.Millisecond,
+		Jitter:         1,
+		JitterSource: func() float64 {
+			return -1
+		},
+	}
+
+	if backoff := policy.Backoff(0, nil); backoff < 0 {
+		t.Fatalf("backoff = %s, must not be negative", backoff)
+	}
+}

--- a/loop/retry_policy_test.go
+++ b/loop/retry_policy_test.go
@@ -49,3 +49,17 @@ func TestRetryPolicyBackoffNeverExceedsMaximumWithJitter(t *testing.T) {
 		}
 	}
 }
+
+func TestRetryPolicyBackoffUsesInjectedJitterSource(t *testing.T) {
+	policy := loop.RetryPolicy{
+		InitialBackoff: 10 * time.Millisecond,
+		Jitter:         0.5,
+		JitterSource: func() float64 {
+			return 0.75
+		},
+	}
+
+	if backoff := policy.Backoff(0, nil); backoff != 12500*time.Microsecond {
+		t.Fatalf("backoff = %s, want 12.5ms", backoff)
+	}
+}

--- a/loop/retry_policy_test.go
+++ b/loop/retry_policy_test.go
@@ -50,6 +50,18 @@ func TestRetryPolicyBackoffNeverExceedsMaximumWithJitter(t *testing.T) {
 	}
 }
 
+func TestRetryPolicyBackoffClampsRetryAfterToMaximum(t *testing.T) {
+	policy := loop.RetryPolicy{
+		MaxBackoff:        10 * time.Millisecond,
+		RespectRetryAfter: true,
+	}
+	err := &ai.ProviderError{RetryAfter: time.Second}
+
+	if backoff := policy.Backoff(0, err); backoff != policy.MaxBackoff {
+		t.Fatalf("backoff = %s, want maximum %s", backoff, policy.MaxBackoff)
+	}
+}
+
 func TestRetryPolicyBackoffUsesInjectedJitterSource(t *testing.T) {
 	policy := loop.RetryPolicy{
 		InitialBackoff: 10 * time.Millisecond,

--- a/loop/retry_policy_test.go
+++ b/loop/retry_policy_test.go
@@ -51,6 +51,17 @@ func TestRetryPolicyBackoffNeverExceedsMaximumWithJitter(t *testing.T) {
 	}
 }
 
+func TestRetryPolicyBackoffClampsInitialBackoffToMaximum(t *testing.T) {
+	policy := loop.RetryPolicy{
+		InitialBackoff: time.Second,
+		MaxBackoff:     10 * time.Millisecond,
+	}
+
+	if backoff := policy.Backoff(0, nil); backoff != policy.MaxBackoff {
+		t.Fatalf("backoff = %s, want maximum %s", backoff, policy.MaxBackoff)
+	}
+}
+
 func TestRetryPolicyBackoffClampsRetryAfterToMaximum(t *testing.T) {
 	policy := loop.RetryPolicy{
 		MaxBackoff:        10 * time.Millisecond,

--- a/loop/retry_policy_test.go
+++ b/loop/retry_policy_test.go
@@ -1,0 +1,37 @@
+package loop_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/lace-ai/gai/ai"
+	"github.com/lace-ai/gai/loop"
+)
+
+func TestRetryPolicyClassifiesProviderErrors(t *testing.T) {
+	policy := loop.RetryPolicy{MaxRetries: 1}
+	if !policy.ShouldRetry(0, &ai.ProviderError{Kind: ai.ProviderErrorRateLimited}) {
+		t.Fatal("rate limit should retry")
+	}
+	if policy.ShouldRetry(0, &ai.ProviderError{Kind: ai.ProviderErrorInvalidRequest}) {
+		t.Fatal("invalid request must not retry")
+	}
+	if policy.ShouldRetry(1, &ai.ProviderError{Kind: ai.ProviderErrorTransient}) {
+		t.Fatal("exhausted retries must not retry")
+	}
+}
+
+func TestRetryPolicyAttemptTimeoutRetriesButCallerCancellationDoesNot(t *testing.T) {
+	policy := loop.RetryPolicy{MaxRetries: 1, AttemptTimeout: time.Millisecond}
+	if !policy.ShouldRetry(0, loop.ErrAttemptTimeout) {
+		t.Fatal("policy attempt timeout should retry")
+	}
+	if policy.ShouldRetry(0, context.Canceled) || policy.ShouldRetry(0, context.DeadlineExceeded) {
+		t.Fatal("caller cancellation and deadline must not retry")
+	}
+	if !errors.Is(loop.ErrAttemptTimeout, context.DeadlineExceeded) {
+		t.Fatal("attempt timeout must retain deadline identity")
+	}
+}

--- a/loop/retry_policy_test.go
+++ b/loop/retry_policy_test.go
@@ -3,6 +3,7 @@ package loop_test
 import (
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 
@@ -76,6 +77,34 @@ func TestRetryPolicyBackoffUsesInjectedJitterSource(t *testing.T) {
 	}
 }
 
+func TestRetryPolicyBackoffCapsScaledDurationsBeforeConversion(t *testing.T) {
+	t.Run("multiplier", func(t *testing.T) {
+		policy := loop.RetryPolicy{
+			InitialBackoff: time.Second,
+			MaxBackoff:     time.Millisecond,
+			Multiplier:     math.MaxFloat64,
+		}
+
+		if backoff := policy.Backoff(1, nil); backoff != policy.MaxBackoff {
+			t.Fatalf("backoff = %s, want maximum %s", backoff, policy.MaxBackoff)
+		}
+	})
+
+	t.Run("jitter", func(t *testing.T) {
+		policy := loop.RetryPolicy{
+			InitialBackoff: time.Duration(math.MaxInt64),
+			Jitter:         1,
+			JitterSource: func() float64 {
+				return math.Nextafter(1, 0)
+			},
+		}
+
+		if backoff := policy.Backoff(0, nil); backoff != time.Duration(math.MaxInt64) {
+			t.Fatalf("backoff = %s, want maximum duration", backoff)
+		}
+	})
+}
+
 func TestRetryPolicyValidateRejectsInvalidPublicValues(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -86,6 +115,9 @@ func TestRetryPolicyValidateRejectsInvalidPublicValues(t *testing.T) {
 		{name: "negative maximum backoff", policy: loop.RetryPolicy{MaxBackoff: -time.Nanosecond}},
 		{name: "negative attempt timeout", policy: loop.RetryPolicy{AttemptTimeout: -time.Nanosecond}},
 		{name: "negative total timeout", policy: loop.RetryPolicy{TotalTimeout: -time.Nanosecond}},
+		{name: "NaN multiplier", policy: loop.RetryPolicy{Multiplier: math.NaN()}},
+		{name: "positive infinite multiplier", policy: loop.RetryPolicy{Multiplier: math.Inf(1)}},
+		{name: "negative infinite multiplier", policy: loop.RetryPolicy{Multiplier: math.Inf(-1)}},
 		{name: "negative jitter", policy: loop.RetryPolicy{Jitter: -0.01}},
 		{name: "jitter above one", policy: loop.RetryPolicy{Jitter: 1.01}},
 	}

--- a/loop/retry_policy_test.go
+++ b/loop/retry_policy_test.go
@@ -35,3 +35,17 @@ func TestRetryPolicyAttemptTimeoutRetriesButCallerCancellationDoesNot(t *testing
 		t.Fatal("attempt timeout must retain deadline identity")
 	}
 }
+
+func TestRetryPolicyBackoffNeverExceedsMaximumWithJitter(t *testing.T) {
+	policy := loop.RetryPolicy{
+		InitialBackoff: 10 * time.Millisecond,
+		MaxBackoff:     10 * time.Millisecond,
+		Multiplier:     2,
+		Jitter:         1,
+	}
+	for range 64 {
+		if backoff := policy.Backoff(1, nil); backoff > policy.MaxBackoff {
+			t.Fatalf("backoff %s exceeds maximum %s", backoff, policy.MaxBackoff)
+		}
+	}
+}


### PR DESCRIPTION
Closes #78

Adds an opt-in RetryPolicy with provider-neutral classifications, deterministic backoff calculation, Retry-After support, total and per-attempt limits, Retries are opt-in: a nil RetryPolicy performs one attempt with no retries; legacy RetryCount configuration has been removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added provider-neutral error classification with status, error codes, request IDs, and retry timing.
  - Added configurable, validated retry policies with limits, timeouts, backoff, jitter, and server-provided delays.
  - Added cancellation-aware retries and retry events showing the reason and delay.
  - Retries are disabled when no policy is configured.

- **Bug Fixes**
  - Improved streaming error handling across supported AI providers.
  - Preserved underlying errors and prevented retries for canceled or non-retryable failures.
  - Improved timeout reporting and retry observability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

















<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces legacy retry counts with an opt-in, provider-neutral retry policy and classifies transient provider failures across supported model adapters.
- Adds validated retry limits, attempt and total timeouts, capped exponential backoff, jitter, and Retry-After support.
- Propagates retry reason and delay through loop events and telemetry.
- Copies retry policies into agent and summary workflows and updates documentation and tests.
- Preserves provider error metadata and underlying error chains across Anthropic, Gemini, Mistral, and OpenAI streams.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| loop/retry_policy.go | Defines retry validation, classification eligibility, capped backoff and jitter, Retry-After handling, and cancellation-aware waiting. |
| loop/loop.go | Integrates policy-controlled retries, attempt and total deadlines, retry events, and policy-based exhaustion reporting into model generation. |
| ai/errors.go | Introduces provider-neutral error metadata, HTTP/code classification, error-chain preservation, and Retry-After parsing. |
| agent/agent.go | Replaces legacy agent retry counts with independently copied retry policies for each workflow. |
| ai/openai/model.go | Converts OpenAI stream failures into provider-neutral classified errors while preserving SDK errors and response metadata. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Model generation attempt] --> B{Stream error?}
    B -- No --> C[Continue loop]
    B -- Yes --> D[Classify provider error or attempt timeout]
    D --> E{Retry policy configured and budget available?}
    E -- No --> F[Return original or exhaustion error]
    E -- Yes --> G[Calculate capped backoff]
    G --> H[Emit retry event]
    H --> I[Cancellation-aware wait]
    I --> A
```
</details>

<sub>Reviews (11): Last reviewed commit: ["fix(retry): preserve nil-policy error se..."](https://github.com/lace-ai/gai/commit/c0de9897f22f009d77940f93c764122a9b17a515) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54695257)</sub>

<!-- /greptile_comment -->