### PR TITLE
feat(openai): add local tiktoken tokenizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,14 +313,6 @@ builder := gaictx.New(gaictx.Definition{
 
 `BuildContext` allocates budget to context sources. `BuildPrompt` then renders the current user input and accumulated conversation for each loop iteration.
 
-### OpenAI local tokenizer
-
-`ai/openai.NewTokenizer(model)` explicitly enables a local, no-network text tokenizer for known OpenAI model families. `Model.Tokenizer()` exposes the same tokenizer only for those known mappings, so existing agent prompt-builder fallback behavior remains unchanged for unknown models. The mapping is deliberately conservative: GPT-5, GPT-4.1, GPT-4o, and o1/o3/o4 use `o200k_base`; GPT-4 uses `cl100k_base`. Model revisions are accepted only under those documented family prefixes. Unknown names return `*openai.TokenizerUnavailableError` (which matches `ai.ErrTokenizerUnsupported`) from the explicit factory and return `nil` from the legacy model method.
-
-The returned ID is versioned, for example `openai.tiktoken-go/v0.8.1:o200k_base`. Counts are exact for the selected text encoding, not for provider request framing, chat messages, tool payload formatting, or billed request usage. This narrow `ai.Tokenizer` adapter is intended to migrate cleanly to the count-only local-counter abstraction planned in #144.
-
-This capability depends on MIT-licensed [`github.com/tiktoken-go/tokenizer` v0.8.1](https://github.com/tiktoken-go/tokenizer), whose embedded vocabularies add roughly 4 MiB upstream before Go linking (and its `regexp2` dependency). A stripped minimal GAI/OpenAI program that calls `Model.Tokenizer()` measured 6,365,449 bytes before this dependency and 18,149,641 bytes after it (+11,784,192 bytes); actual application impact depends on existing reachability and linker settings. The upstream tokenizer does not handle special tokens; do not use these text-only counts as an exact OpenAI request or billing preflight.
-
 ## History and summarization
 
 `context/history` provides a `ContextSource` backed by a `HistoryStore`. It loads persisted state, selects recent turns that fit the available budget, and reuses cached per-turn token counts.

--- a/README.md
+++ b/README.md
@@ -313,6 +313,14 @@ builder := gaictx.New(gaictx.Definition{
 
 `BuildContext` allocates budget to context sources. `BuildPrompt` then renders the current user input and accumulated conversation for each loop iteration.
 
+### OpenAI local tokenizer
+
+`ai/openai.NewTokenizer(model)` explicitly enables a local, no-network text tokenizer for known OpenAI model families. `Model.Tokenizer()` exposes the same tokenizer only for those known mappings, so existing agent prompt-builder fallback behavior remains unchanged for unknown models. The mapping is deliberately conservative: GPT-5, GPT-4.1, GPT-4o, and o1/o3/o4 use `o200k_base`; GPT-4 uses `cl100k_base`. Model revisions are accepted only under those documented family prefixes. Unknown names return `*openai.TokenizerUnavailableError` (which matches `ai.ErrTokenizerUnsupported`) from the explicit factory and return `nil` from the legacy model method.
+
+The returned ID is versioned, for example `openai.tiktoken-go/v0.8.1:o200k_base`. Counts are exact for the selected text encoding, not for provider request framing, chat messages, tool payload formatting, or billed request usage. This narrow `ai.Tokenizer` adapter is intended to migrate cleanly to the count-only local-counter abstraction planned in #144.
+
+This capability depends on MIT-licensed [`github.com/tiktoken-go/tokenizer` v0.8.1](https://github.com/tiktoken-go/tokenizer), whose embedded vocabularies add roughly 4 MiB upstream before Go linking (and its `regexp2` dependency). A stripped minimal GAI/OpenAI program that calls `Model.Tokenizer()` measured 6,365,449 bytes before this dependency and 18,149,641 bytes after it (+11,784,192 bytes); actual application impact depends on existing reachability and linker settings. The upstream tokenizer does not handle special tokens; do not use these text-only counts as an exact OpenAI request or billing preflight.
+
 ## History and summarization
 
 `context/history` provides a `ContextSource` backed by a `HistoryStore`. It loads persisted state, selects recent turns that fit the available budget, and reuses cached per-turn token counts.

--- a/ai/openai/model.go
+++ b/ai/openai/model.go
@@ -44,9 +44,15 @@ func (m *Model) NativeTools() bool { return true }
 
 func (m *Model) Close() error { return nil }
 
-// Tokenizer returns nil because OpenAI tokenization is not implemented by this provider.
-// This prevents callers from installing an unusable tokenizer into prompt or history flows.
-func (m *Model) Tokenizer() ai.Tokenizer { return nil }
+// Tokenizer returns a local tokenizer only when this model has a known encoding.
+// Unknown models remain nil so callers retain their configured fallback behavior.
+func (m *Model) Tokenizer() ai.Tokenizer {
+	tokenizer, err := NewTokenizer(m.name)
+	if err != nil {
+		return nil
+	}
+	return tokenizer
+}
 
 func (m *Model) Descriptor() ai.ModelDescriptor {
 	if facts, ok := m.provider.catalog.Lookup(m.name); ok {
@@ -360,6 +366,9 @@ func openAIDescriptor(model string) ai.ModelDescriptor {
 		ToolCalling: ai.FeatureSupportSupported,
 		JSONOutput:  ai.FeatureSupportSupported, JSONSchemaOutput: ai.FeatureSupportSupported,
 		Tokenizer: ai.TokenizerDescriptor{Available: ai.FeatureSupportUnsupported},
+	}
+	if isTokenizerAvailableForModel(model) {
+		d.Tokenizer = ai.TokenizerDescriptor{Available: ai.FeatureSupportSupported, Fidelity: ai.TokenizerFidelityEstimated}
 	}
 	if efforts := gpt5ReasoningEfforts(model); len(efforts) > 0 {
 		d.ReasoningEffort = ai.FeatureSupportSupported

--- a/ai/openai/model_test.go
+++ b/ai/openai/model_test.go
@@ -927,17 +927,17 @@ func TestOpenAIDescriptorUsesReasoningFamilyOverlay(t *testing.T) {
 	}
 }
 
-func TestModelTokenizerIsNilWhenTokenizationIsUnavailable(t *testing.T) {
+func TestModelTokenizerUsesLocalTokenizerWhenEncodingIsKnown(t *testing.T) {
 	m := &Model{name: GPT41}
-	if tokenizer := m.Tokenizer(); tokenizer != nil {
-		t.Fatalf("Tokenizer() = %T, want nil when tokenization is unavailable", tokenizer)
+	if tokenizer := m.Tokenizer(); tokenizer == nil {
+		t.Fatal("Tokenizer() = nil, want local tokenizer for a known encoding")
 	}
 }
 
-func TestModelDescriptorDoesNotAdvertiseUnsupportedTokenizer(t *testing.T) {
+func TestModelDescriptorAdvertisesKnownLocalTokenizer(t *testing.T) {
 	d := openAIDescriptor(GPT41)
-	if d.Tokenizer.Available != ai.FeatureSupportUnsupported || d.Tokenizer.Fidelity != ai.TokenizerFidelityUnknown {
-		t.Fatalf("tokenizer descriptor = %#v, want unsupported/unknown", d.Tokenizer)
+	if d.Tokenizer.Available != ai.FeatureSupportSupported || d.Tokenizer.Fidelity != ai.TokenizerFidelityEstimated {
+		t.Fatalf("tokenizer descriptor = %#v, want supported/estimated", d.Tokenizer)
 	}
 	if d.NativeMessages != ai.FeatureSupportSupported || d.NativeTools != ai.FeatureSupportSupported || d.Multimodal != ai.FeatureSupportUnsupported || d.Usage != ai.FeatureSupportSupported || d.FinishReason != ai.FeatureSupportSupported || d.StreamingUsage != ai.FeatureSupportSupported {
 		t.Fatalf("capability descriptor = %#v", d)

--- a/ai/openai/tokenizer.go
+++ b/ai/openai/tokenizer.go
@@ -81,7 +81,7 @@ func (t *Tokenizer) Tokenize(ctx context.Context, text string) ([]string, error)
 func openAIEncodingForModel(model string) (tiktoken.Encoding, bool) {
 	model = strings.ToLower(strings.TrimSpace(model))
 	switch model {
-	case "gpt-5", GPT56, GPT56Terra, GPT56Sol, GPT56Luna, GPT41, GPT41Mini, GPT41Nano, GPT4o, GPT4oMini, O3, O3Mini, O4Mini:
+	case "gpt-5", GPT56, GPT56Terra, GPT56Sol, GPT56Luna, GPT41, GPT41Mini, GPT41Nano, GPT4o, GPT4oMini, "o1", O3, O3Mini, O4Mini:
 		return tiktoken.O200kBase, true
 	case "gpt-4":
 		return tiktoken.Cl100kBase, true

--- a/ai/openai/tokenizer.go
+++ b/ai/openai/tokenizer.go
@@ -81,7 +81,7 @@ func (t *Tokenizer) Tokenize(ctx context.Context, text string) ([]string, error)
 func openAIEncodingForModel(model string) (tiktoken.Encoding, bool) {
 	model = strings.ToLower(strings.TrimSpace(model))
 	switch model {
-	case "gpt-5", GPT56, GPT56Terra, GPT56Sol, GPT56Luna, GPT41, GPT41Mini, GPT41Nano, GPT4o, GPT4oMini, "o1", O3, O3Mini, O4Mini:
+	case "gpt-5", "gpt-5.1", GPT56, GPT56Terra, GPT56Sol, GPT56Luna, GPT41, GPT41Mini, GPT41Nano, GPT4o, GPT4oMini, "o1", O3, O3Mini, O4Mini:
 		return tiktoken.O200kBase, true
 	case "gpt-4":
 		return tiktoken.Cl100kBase, true
@@ -90,6 +90,7 @@ func openAIEncodingForModel(model string) (tiktoken.Encoding, bool) {
 		prefix   string
 		encoding tiktoken.Encoding
 	}{
+		{"gpt-5.1-", tiktoken.O200kBase},
 		{"gpt-5-", tiktoken.O200kBase},
 		{"gpt-4.1-", tiktoken.O200kBase},
 		{"gpt-4o-", tiktoken.O200kBase},

--- a/ai/openai/tokenizer.go
+++ b/ai/openai/tokenizer.go
@@ -1,0 +1,118 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/lace-ai/gai/ai"
+	tiktoken "github.com/tiktoken-go/tokenizer"
+)
+
+const tokenizerIDPrefix = "openai.tiktoken-go/v0.8.1:"
+
+// TokenizerUnavailableError reports that no local tokenizer mapping is known
+// for a model. It intentionally does not guess an encoding for unknown models.
+type TokenizerUnavailableError struct {
+	Model string
+}
+
+func (e *TokenizerUnavailableError) Error() string {
+	return fmt.Sprintf("openai tokenizer unavailable for model %q", e.Model)
+}
+
+func (e *TokenizerUnavailableError) Unwrap() error { return ai.ErrTokenizerUnsupported }
+
+// NewTokenizer returns a local tokenizer for a supported OpenAI model.
+//
+// Counts are exact for the selected text encoding, but do not include OpenAI
+// request framing, messages, tools, or billing overhead. It performs no
+// provider network I/O. Unknown models return a TokenizerUnavailableError so a
+// caller can choose its own fallback; they are never assigned a guessed codec.
+func NewTokenizer(model string) (ai.Tokenizer, error) {
+	model = strings.TrimSpace(model)
+	encoding, ok := openAIEncodingForModel(model)
+	if !ok {
+		return nil, &TokenizerUnavailableError{Model: model}
+	}
+	codec, err := tiktoken.Get(encoding)
+	if err != nil {
+		return nil, fmt.Errorf("load OpenAI tokenizer %q: %w", encoding, err)
+	}
+	return &Tokenizer{codec: codec, encoding: encoding}, nil
+}
+
+// Tokenizer is a local text-encoding tokenizer backed by tiktoken-go.
+// Its API is deliberately limited to ai.Tokenizer so it can be adapted to the
+// count-only TokenCounter contract planned in #144 without exposing a second
+// provider-specific abstraction.
+type Tokenizer struct {
+	codec    tiktoken.Codec
+	encoding tiktoken.Encoding
+}
+
+var _ ai.Tokenizer = (*Tokenizer)(nil)
+
+func (t *Tokenizer) ID() string { return tokenizerIDPrefix + string(t.encoding) }
+
+func (t *Tokenizer) CountTokens(ctx context.Context, text string) (int, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+	count, err := t.codec.Count(text)
+	if err != nil {
+		return 0, fmt.Errorf("count OpenAI tokens: %w", err)
+	}
+	return count, nil
+}
+
+func (t *Tokenizer) Tokenize(ctx context.Context, text string) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	_, tokens, err := t.codec.Encode(text)
+	if err != nil {
+		return nil, fmt.Errorf("tokenize OpenAI text: %w", err)
+	}
+	return tokens, nil
+}
+
+func openAIEncodingForModel(model string) (tiktoken.Encoding, bool) {
+	model = strings.ToLower(strings.TrimSpace(model))
+	switch model {
+	case "gpt-5", GPT56, GPT56Terra, GPT56Sol, GPT56Luna, GPT41, GPT41Mini, GPT41Nano, GPT4o, GPT4oMini, O3, O3Mini, O4Mini:
+		return tiktoken.O200kBase, true
+	case "gpt-4":
+		return tiktoken.Cl100kBase, true
+	}
+	for _, mapping := range []struct {
+		prefix   string
+		encoding tiktoken.Encoding
+	}{
+		{"gpt-5-", tiktoken.O200kBase},
+		{"gpt-4.1-", tiktoken.O200kBase},
+		{"gpt-4o-", tiktoken.O200kBase},
+		{"o1-", tiktoken.O200kBase},
+		{"o3-", tiktoken.O200kBase},
+		{"o4-", tiktoken.O200kBase},
+		{"gpt-4-", tiktoken.Cl100kBase},
+	} {
+		if strings.HasPrefix(model, mapping.prefix) {
+			return mapping.encoding, true
+		}
+	}
+	return "", false
+}
+
+func isTokenizerAvailableForModel(model string) bool {
+	_, ok := openAIEncodingForModel(model)
+	return ok
+}
+
+// IsTokenizerUnavailable reports whether err identifies an unsupported local
+// OpenAI model-to-encoding mapping.
+func IsTokenizerUnavailable(err error) bool {
+	var unavailable *TokenizerUnavailableError
+	return errors.As(err, &unavailable)
+}

--- a/ai/openai/tokenizer_test.go
+++ b/ai/openai/tokenizer_test.go
@@ -17,6 +17,7 @@ func TestNewTokenizerResolvesKnownOpenAIModels(t *testing.T) {
 		want   int
 	}{
 		{model: "gpt-5", wantID: "openai.tiktoken-go/v0.8.1:o200k_base", text: "hello", want: 1},
+		{model: "o1", wantID: "openai.tiktoken-go/v0.8.1:o200k_base", text: "hello", want: 1},
 		{model: GPT41, wantID: "openai.tiktoken-go/v0.8.1:o200k_base", text: "hello", want: 1},
 		{model: GPT4oMini, wantID: "openai.tiktoken-go/v0.8.1:o200k_base", text: "hello", want: 1},
 		{model: "gpt-4-0125-preview", wantID: "openai.tiktoken-go/v0.8.1:cl100k_base", text: `{"tool":"weather","city":"München"}`, want: 10},

--- a/ai/openai/tokenizer_test.go
+++ b/ai/openai/tokenizer_test.go
@@ -1,0 +1,110 @@
+package openai
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/lace-ai/gai/ai"
+)
+
+func TestNewTokenizerResolvesKnownOpenAIModels(t *testing.T) {
+	tests := []struct {
+		model  string
+		wantID string
+		text   string
+		want   int
+	}{
+		{model: "gpt-5", wantID: "openai.tiktoken-go/v0.8.1:o200k_base", text: "hello", want: 1},
+		{model: GPT41, wantID: "openai.tiktoken-go/v0.8.1:o200k_base", text: "hello", want: 1},
+		{model: GPT4oMini, wantID: "openai.tiktoken-go/v0.8.1:o200k_base", text: "hello", want: 1},
+		{model: "gpt-4-0125-preview", wantID: "openai.tiktoken-go/v0.8.1:cl100k_base", text: `{"tool":"weather","city":"München"}`, want: 10},
+	}
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			tokenizer, err := NewTokenizer(tt.model)
+			if err != nil {
+				t.Fatalf("NewTokenizer(%q) error: %v", tt.model, err)
+			}
+			if tokenizer.ID() != tt.wantID {
+				t.Fatalf("ID() = %q, want %q", tokenizer.ID(), tt.wantID)
+			}
+			got, err := tokenizer.CountTokens(context.Background(), tt.text)
+			if err != nil || got != tt.want {
+				t.Fatalf("CountTokens(%q) = %d, %v; want %d, nil", tt.text, got, err, tt.want)
+			}
+			tokens, err := tokenizer.Tokenize(context.Background(), tt.text)
+			if err != nil {
+				t.Fatalf("Tokenize(%q) error: %v", tt.text, err)
+			}
+			if len(tokens) != got {
+				t.Fatalf("len(Tokenize(%q)) = %d, want CountTokens result %d", tt.text, len(tokens), got)
+			}
+		})
+	}
+}
+
+func TestNewTokenizerRejectsUnknownModelWithTypedUnavailability(t *testing.T) {
+	_, err := NewTokenizer("gpt-future-999")
+	if err == nil {
+		t.Fatal("NewTokenizer() error = nil, want unavailable error")
+	}
+	var unavailable *TokenizerUnavailableError
+	if !errors.As(err, &unavailable) {
+		t.Fatalf("NewTokenizer() error = %T %v, want *TokenizerUnavailableError", err, err)
+	}
+	if unavailable.Model != "gpt-future-999" {
+		t.Fatalf("unavailable model = %q, want %q", unavailable.Model, "gpt-future-999")
+	}
+	if !errors.Is(err, ai.ErrTokenizerUnsupported) {
+		t.Fatalf("NewTokenizer() error = %v, want ai.ErrTokenizerUnsupported", err)
+	}
+}
+
+func TestModelTokenizerUsesExplicitResolverAndPreservesUnavailableFallback(t *testing.T) {
+	if tokenizer := (&Model{name: GPT41}).Tokenizer(); tokenizer == nil {
+		t.Fatal("Tokenizer() = nil for a supported model")
+	}
+	if tokenizer := (&Model{name: "gpt-future-999"}).Tokenizer(); tokenizer != nil {
+		t.Fatalf("Tokenizer() = %T for an unsupported model, want nil", tokenizer)
+	}
+}
+
+func TestTokenizerHonorsCanceledContextWithoutProviderIO(t *testing.T) {
+	tokenizer, err := NewTokenizer(GPT41)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := tokenizer.CountTokens(ctx, "hello"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("CountTokens() error = %v, want context.Canceled", err)
+	}
+	if _, err := tokenizer.Tokenize(ctx, "hello"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Tokenize() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestTokenizerTokenizesRepresentativeToolPayloadDeterministically(t *testing.T) {
+	tokenizer, err := NewTokenizer(GPT41)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := `{"name":"weather","description":"Get weather for München","parameters":{"type":"object","properties":{"city":{"type":"string"}}}}}`
+	first, err := tokenizer.Tokenize(context.Background(), payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := tokenizer.Tokenize(context.Background(), payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(first, second) {
+		t.Fatalf("Tokenize() is not deterministic: first=%q second=%q", first, second)
+	}
+	count, err := tokenizer.CountTokens(context.Background(), payload)
+	if err != nil || count != len(first) {
+		t.Fatalf("CountTokens() = %d, %v; want %d, nil", count, err, len(first))
+	}
+}

--- a/ai/openai/tokenizer_test.go
+++ b/ai/openai/tokenizer_test.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"reflect"
 	"testing"
@@ -87,25 +88,56 @@ func TestTokenizerHonorsCanceledContextWithoutProviderIO(t *testing.T) {
 	}
 }
 
-func TestTokenizerTokenizesRepresentativeToolPayloadDeterministically(t *testing.T) {
+var realisticToolSchemaJSONFixtures = []struct {
+	name string
+	json string
+	want int
+}{
+	{
+		name: "web search with nested filters",
+		json: `{"name":"web_search","description":"Search the public web for current information and return source URLs.","parameters":{"type":"object","additionalProperties":false,"properties":{"query":{"type":"string","description":"Natural-language search query"},"recency_days":{"type":"integer","minimum":1,"maximum":30},"domains":{"type":"array","items":{"type":"string","format":"hostname"}}},"required":["query"]}}`,
+		want: 85,
+	},
+	{
+		name: "calendar event with attendees",
+		json: `{"name":"create_calendar_event","description":"Create a calendar event after the user confirms the proposed time.","parameters":{"type":"object","additionalProperties":false,"properties":{"title":{"type":"string"},"starts_at":{"type":"string","format":"date-time"},"duration_minutes":{"type":"integer","minimum":15,"maximum":480},"attendees":{"type":"array","items":{"type":"object","additionalProperties":false,"properties":{"email":{"type":"string","format":"email"},"optional":{"type":"boolean"}},"required":["email"]}},"send_updates":{"type":"boolean","default":true}},"required":["title","starts_at"]}}`,
+		want: 133,
+	},
+	{
+		name: "customer lookup with message context",
+		json: `{"messages":[{"role":"system","content":"Use this tool only for authorized support requests."},{"role":"user","content":"Find the subscription for ada@example.com and include the latest invoice status."}],"tool":{"name":"lookup_customer","description":"Retrieve a customer profile and recent invoices by a verified identifier.","parameters":{"type":"object","additionalProperties":false,"properties":{"email":{"type":"string","format":"email"},"include_invoices":{"type":"boolean","default":false},"invoice_limit":{"type":"integer","minimum":1,"maximum":10}},"required":["email"]}}}`,
+		want: 121,
+	},
+}
+
+func TestTokenizerCountsRealisticToolSchemaJSONFixtures(t *testing.T) {
 	tokenizer, err := NewTokenizer(GPT41)
 	if err != nil {
 		t.Fatal(err)
 	}
-	payload := `{"name":"weather","description":"Get weather for München","parameters":{"type":"object","properties":{"city":{"type":"string"}}}}}`
-	first, err := tokenizer.Tokenize(context.Background(), payload)
-	if err != nil {
-		t.Fatal(err)
-	}
-	second, err := tokenizer.Tokenize(context.Background(), payload)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(first, second) {
-		t.Fatalf("Tokenize() is not deterministic: first=%q second=%q", first, second)
-	}
-	count, err := tokenizer.CountTokens(context.Background(), payload)
-	if err != nil || count != len(first) {
-		t.Fatalf("CountTokens() = %d, %v; want %d, nil", count, err, len(first))
+	for _, fixture := range realisticToolSchemaJSONFixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			if !json.Valid([]byte(fixture.json)) {
+				t.Fatal("fixture is not valid JSON")
+			}
+			first, err := tokenizer.Tokenize(t.Context(), fixture.json)
+			if err != nil {
+				t.Fatal(err)
+			}
+			second, err := tokenizer.Tokenize(t.Context(), fixture.json)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(first, second) {
+				t.Fatalf("Tokenize() is not deterministic: first=%q second=%q", first, second)
+			}
+			count, err := tokenizer.CountTokens(t.Context(), fixture.json)
+			if err != nil || count != fixture.want {
+				t.Fatalf("CountTokens() = %d, %v; want %d, nil", count, err, fixture.want)
+			}
+			if len(first) != count {
+				t.Fatalf("len(Tokenize()) = %d, want CountTokens result %d", len(first), count)
+			}
+		})
 	}
 }

--- a/ai/openai/tokenizer_test.go
+++ b/ai/openai/tokenizer_test.go
@@ -18,6 +18,8 @@ func TestNewTokenizerResolvesKnownOpenAIModels(t *testing.T) {
 		want   int
 	}{
 		{model: "gpt-5", wantID: "openai.tiktoken-go/v0.8.1:o200k_base", text: "hello", want: 1},
+		{model: "gpt-5.1", wantID: "openai.tiktoken-go/v0.8.1:o200k_base", text: "hello", want: 1},
+		{model: "gpt-5.1-codex", wantID: "openai.tiktoken-go/v0.8.1:o200k_base", text: "hello", want: 1},
 		{model: "o1", wantID: "openai.tiktoken-go/v0.8.1:o200k_base", text: "hello", want: 1},
 		{model: GPT41, wantID: "openai.tiktoken-go/v0.8.1:o200k_base", text: "hello", want: 1},
 		{model: GPT4oMini, wantID: "openai.tiktoken-go/v0.8.1:o200k_base", text: "hello", want: 1},

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.1
 require (
 	github.com/anthropics/anthropic-sdk-go v1.63.1
 	github.com/openai/openai-go v1.12.0
+	github.com/tiktoken-go/tokenizer v0.8.1
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.45.0
 	go.opentelemetry.io/otel/sdk v1.45.0
@@ -20,6 +21,7 @@ require (
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/dlclark/regexp2/v2 v2.5.1 // indirect
 	github.com/eliben/go-sentencepiece v0.7.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UF
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2/v2 v2.5.1 h1:E5Ug7Dh264W1ymdySmiHNcDG7fmsR307APCE5R07a20=
+github.com/dlclark/regexp2/v2 v2.5.1/go.mod h1:avUrQvPaLz2DrFNHJF0taWAFFX2C1GMSSoeiqFjcBmU=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/eliben/go-sentencepiece v0.7.0 h1:QpP9HpLXF7/TAZoskolXm7heEWkh9vpHVUgGR1AbY3o=
@@ -65,6 +67,8 @@ github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
 github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
+github.com/tiktoken-go/tokenizer v0.8.1 h1:4obDoB6/dhdBt9xMweX4nww5cjdOq/nYF4ecwPq2+mg=
+github.com/tiktoken-go/tokenizer v0.8.1/go.mod h1:eLA0t6nGvn9mDc7gt90qt7pMat+gE9ViqwQ6l9B+tA4=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.68.0 h1:CqXxU8VOmDefoh0+ztfGaymYbhdB/tT3zs79QaZTNGY=


### PR DESCRIPTION
## Summary
- add an explicit, no-network OpenAI local tokenizer backed by `tiktoken-go` v0.8.1
- resolve conservative known model encodings with typed unavailability for unknown models
- expose supported tokenizer metadata while retaining nil legacy fallback for unknown models
- document fidelity, license, special-token limitation, and measured binary impact

## Validation
- `go test ./...`
- `go vet ./...`
- `git diff --check`

Closes #121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local tokenization support for recognized OpenAI models, including GPT-5.1 and o1.
  * Added token counting and text tokenization with model-specific encoding detection.
  * Added clear handling for unsupported or unknown models.

* **Bug Fixes**
  * Model descriptors now accurately indicate when tokenizer support is available.

* **Tests**
  * Expanded coverage for model resolution, token counts, cancellation, error handling, and realistic tool-schema content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds local, no-network OpenAI text tokenization using `tiktoken-go`, including model-to-encoding resolution and tokenizer capability metadata.
- Supports known GPT and o-series models while preserving the legacy nil fallback for unknown models.
- Adds typed unavailability errors, cancellation handling, deterministic tokenization tests, and tokenizer fidelity metadata.
- Adds the tokenizer dependency and its transitive regular-expression dependency.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the prior bare `o1` tokenizer issue is fixed by the exact resolver mapping and regression coverage.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| ai/openai/tokenizer.go | Adds the local tokenizer, conservative model resolution, typed unsupported-model handling, and context cancellation checks; the prior bare-o1 issue is fixed. |
| ai/openai/tokenizer_test.go | Covers known and unknown models, bare `o1`, cancellation, deterministic tokenization, and representative JSON payload counts. |
| ai/openai/model.go | Integrates local tokenizers with models and advertises estimated tokenizer availability for recognized model encodings. |
| ai/openai/model_test.go | Updates model-level tests to verify tokenizer availability and descriptor metadata. |
| go.mod | Adds `tiktoken-go` v0.8.1 and its indirect regular-expression dependency. |
| go.sum | Records checksums for the newly added tokenizer dependency graph. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  M[OpenAI Model] --> R[Model-to-encoding resolver]
  R -->|Known model| C[tiktoken codec]
  C --> T[Local Tokenizer]
  T --> N[CountTokens]
  T --> E[Tokenize]
  R -->|Unknown model| U[Typed unavailable error]
  U --> F[Legacy nil fallback]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix: support GPT-5.1 tokenizer mapping"](https://github.com/lace-ai/gai/commit/b3130a79e3ed4a14e5f9817ef17ca9f10342553e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55830836)</sub>

**Context used:**

- Knowledge Base — [AI requests, responses, and model contracts](https://app.greptile.com/laceai/-/custom-context/knowledge-base/lace-ai/gai/-/docs/ai-contracts.md)
- Knowledge Base — [AI provider integrations](https://app.greptile.com/laceai/-/custom-context/knowledge-base/lace-ai/gai/-/docs/ai-provider-integrations.md)

<!-- /greptile_comment -->